### PR TITLE
client(admin): pick primary slug, not auto-generated, for 'the link'

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -39,6 +39,16 @@ function t(key, params) {
   return val;
 }
 
+// The slug to display or copy when "the link" needs one representative chip:
+// the link's primary, with slugs[0] as a defensive fallback for malformed data.
+function pickPrimarySlug(link) {
+  if (!link.slugs || link.slugs.length === 0) return null;
+  for (var i = 0; i < link.slugs.length; i++) {
+    if (link.slugs[i].is_primary) return link.slugs[i];
+  }
+  return link.slugs[0];
+}
+
 // ---- Toast ----
 function toast(msg, type) {
   var el = document.getElementById('toast');
@@ -150,7 +160,7 @@ function quickShorten() {
             window.location.href = '/_/admin/links/' + link.id;
           }
         } else {
-          var primary = link.slugs.find(function(s) { return s.is_primary; }) || link.slugs[0];
+          var primary = pickPrimarySlug(link);
           if (primary) copyUrl(primary.slug);
           toast(t('client.linkCreatedCopied'));
           window.location.href = '/_/admin/links/' + link.id;
@@ -247,7 +257,7 @@ function createDuplicate(url) {
   api('/links', { method: 'POST', body: JSON.stringify({ url: url, allow_duplicate: true }) }).then(function(res) {
     if (res.ok) {
       return res.json().then(function(link) {
-        var primary = link.slugs.find(function(s) { return s.is_primary; }) || link.slugs[0];
+        var primary = pickPrimarySlug(link);
         if (primary) copyUrl(primary.slug);
         toast(t('client.linkCreatedCopied'));
         window.location.href = '/_/admin/links/' + link.id;
@@ -1125,11 +1135,8 @@ function pollDashboard() {
         if (recentNoData) recentNoData.remove();
         for (var ri = 0; ri < d.recent_links.length; ri++) {
           var link = d.recent_links[ri];
-          var slug = '';
-          for (var si = 0; si < link.slugs.length; si++) {
-            if (link.slugs[si].is_primary) { slug = link.slugs[si].slug; break; }
-          }
-          if (!slug && link.slugs.length > 0) slug = link.slugs[0].slug;
+          var primarySlug = pickPrimarySlug(link);
+          var slug = primarySlug ? primarySlug.slug : '';
           var a = document.createElement('a');
           a.href = '/_/admin/links/' + link.id;
           a.style.cssText = 'display:flex;align-items:center;gap:0.75rem;padding:0.5rem 0;cursor:pointer;overflow:hidden;min-width:0;text-decoration:none;color:inherit';
@@ -1161,11 +1168,8 @@ function pollDashboard() {
         if (tlNoData) tlNoData.remove();
         for (var ti = 0; ti < d.top_links.length; ti++) {
           var tLink = d.top_links[ti];
-          var tSlug = '';
-          for (var si = 0; si < tLink.slugs.length; si++) {
-            if (tLink.slugs[si].is_primary) { tSlug = tLink.slugs[si].slug; break; }
-          }
-          if (!tSlug && tLink.slugs.length > 0) tSlug = tLink.slugs[0].slug;
+          var tPrimary = pickPrimarySlug(tLink);
+          var tSlug = tPrimary ? tPrimary.slug : '';
           var tPct = Math.round((tLink.total_clicks / tlMax) * 100);
           var a = document.createElement('a');
           a.href = '/_/admin/links/' + tLink.id;
@@ -1503,11 +1507,8 @@ function showAddLinkToBundlePicker(bundleId, excludeIds) {
         html += '<div class="muted-hint">' + esc(t('bundles.allLinksAdded')) + '</div>';
       } else {
         available.forEach(function(link) {
-          var slug = '';
-          if (link.slugs && link.slugs.length > 0) {
-            var primary = link.slugs.find(function(s) { return s.is_primary; }) || link.slugs[0];
-            slug = primary.slug;
-          }
+          var primary = pickPrimarySlug(link);
+          var slug = primary ? primary.slug : '';
           var label = link.label || link.url;
           html += '<div class="add-to-bundle-row" data-search="' + esc((link.label || '') + ' ' + link.url + ' ' + slug).toLowerCase() + '" onclick="doAddLinkToBundle(' + bundleId + ',' + link.id + ')">';
           html += '<span class="slug-chip">' + esc(slug) + '</span>';

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,14 +39,14 @@ function t(key, params) {
   return val;
 }
 
-// The slug to display or copy when "the link" needs one representative chip:
-// the link's primary, with slugs[0] as a defensive fallback for malformed data.
+// The slug string to display or copy when "the link" needs one representative
+// chip: the link's primary, falling back to the first slug.
 function pickPrimarySlug(link) {
-  if (!link.slugs || link.slugs.length === 0) return null;
+  if (!link.slugs || link.slugs.length === 0) return '';
   for (var i = 0; i < link.slugs.length; i++) {
-    if (link.slugs[i].is_primary) return link.slugs[i];
+    if (link.slugs[i].is_primary) return link.slugs[i].slug;
   }
-  return link.slugs[0];
+  return link.slugs[0].slug;
 }
 
 // ---- Toast ----
@@ -161,7 +161,7 @@ function quickShorten() {
           }
         } else {
           var primary = pickPrimarySlug(link);
-          if (primary) copyUrl(primary.slug);
+          if (primary) copyUrl(primary);
           toast(t('client.linkCreatedCopied'));
           window.location.href = '/_/admin/links/' + link.id;
         }
@@ -258,7 +258,7 @@ function createDuplicate(url) {
     if (res.ok) {
       return res.json().then(function(link) {
         var primary = pickPrimarySlug(link);
-        if (primary) copyUrl(primary.slug);
+        if (primary) copyUrl(primary);
         toast(t('client.linkCreatedCopied'));
         window.location.href = '/_/admin/links/' + link.id;
       });
@@ -1135,8 +1135,7 @@ function pollDashboard() {
         if (recentNoData) recentNoData.remove();
         for (var ri = 0; ri < d.recent_links.length; ri++) {
           var link = d.recent_links[ri];
-          var primarySlug = pickPrimarySlug(link);
-          var slug = primarySlug ? primarySlug.slug : '';
+          var slug = pickPrimarySlug(link);
           var a = document.createElement('a');
           a.href = '/_/admin/links/' + link.id;
           a.style.cssText = 'display:flex;align-items:center;gap:0.75rem;padding:0.5rem 0;cursor:pointer;overflow:hidden;min-width:0;text-decoration:none;color:inherit';
@@ -1168,8 +1167,7 @@ function pollDashboard() {
         if (tlNoData) tlNoData.remove();
         for (var ti = 0; ti < d.top_links.length; ti++) {
           var tLink = d.top_links[ti];
-          var tPrimary = pickPrimarySlug(tLink);
-          var tSlug = tPrimary ? tPrimary.slug : '';
+          var tSlug = pickPrimarySlug(tLink);
           var tPct = Math.round((tLink.total_clicks / tlMax) * 100);
           var a = document.createElement('a');
           a.href = '/_/admin/links/' + tLink.id;
@@ -1507,8 +1505,7 @@ function showAddLinkToBundlePicker(bundleId, excludeIds) {
         html += '<div class="muted-hint">' + esc(t('bundles.allLinksAdded')) + '</div>';
       } else {
         available.forEach(function(link) {
-          var primary = pickPrimarySlug(link);
-          var slug = primary ? primary.slug : '';
+          var slug = pickPrimarySlug(link);
           var label = link.label || link.url;
           html += '<div class="add-to-bundle-row" data-search="' + esc((link.label || '') + ' ' + link.url + ' ' + slug).toLowerCase() + '" onclick="doAddLinkToBundle(' + bundleId + ',' + link.id + ')">';
           html += '<span class="slug-chip">' + esc(slug) + '</span>';

--- a/src/client.ts
+++ b/src/client.ts
@@ -150,7 +150,7 @@ function quickShorten() {
             window.location.href = '/_/admin/links/' + link.id;
           }
         } else {
-          var primary = link.slugs.find(function(s) { return !s.is_custom; });
+          var primary = link.slugs.find(function(s) { return s.is_primary; }) || link.slugs[0];
           if (primary) copyUrl(primary.slug);
           toast(t('client.linkCreatedCopied'));
           window.location.href = '/_/admin/links/' + link.id;
@@ -247,7 +247,7 @@ function createDuplicate(url) {
   api('/links', { method: 'POST', body: JSON.stringify({ url: url, allow_duplicate: true }) }).then(function(res) {
     if (res.ok) {
       return res.json().then(function(link) {
-        var primary = link.slugs.find(function(s) { return !s.is_custom; });
+        var primary = link.slugs.find(function(s) { return s.is_primary; }) || link.slugs[0];
         if (primary) copyUrl(primary.slug);
         toast(t('client.linkCreatedCopied'));
         window.location.href = '/_/admin/links/' + link.id;
@@ -1127,7 +1127,7 @@ function pollDashboard() {
           var link = d.recent_links[ri];
           var slug = '';
           for (var si = 0; si < link.slugs.length; si++) {
-            if (!link.slugs[si].is_custom) { slug = link.slugs[si].slug; break; }
+            if (link.slugs[si].is_primary) { slug = link.slugs[si].slug; break; }
           }
           if (!slug && link.slugs.length > 0) slug = link.slugs[0].slug;
           var a = document.createElement('a');
@@ -1163,7 +1163,7 @@ function pollDashboard() {
           var tLink = d.top_links[ti];
           var tSlug = '';
           for (var si = 0; si < tLink.slugs.length; si++) {
-            if (!tLink.slugs[si].is_custom) { tSlug = tLink.slugs[si].slug; break; }
+            if (tLink.slugs[si].is_primary) { tSlug = tLink.slugs[si].slug; break; }
           }
           if (!tSlug && tLink.slugs.length > 0) tSlug = tLink.slugs[0].slug;
           var tPct = Math.round((tLink.total_clicks / tlMax) * 100);


### PR DESCRIPTION
Closes #6.

## Summary

Four admin UI sites in `src/client.ts` answered "which slug represents this link" with `link.slugs.find(s => !s.is_custom)`, which returns the auto-generated slug specifically. After `SlugRepository.setPrimary` flips primary to a custom slug, or after a primary custom slug is disabled/removed and the auto-slug is auto-promoted back, that pattern diverges from the canonical "primary, falling back to `slugs[0]`" used at `src/client.ts:1508` and on the redirect path.

Switched all four to `s.is_primary` with the same `|| slugs[0]` fallback:

- `src/client.ts:153` — post-create copy
- `src/client.ts:250` — post-duplicate-create copy
- `src/client.ts:1130` — dashboard "recent links" chip
- `src/client.ts:1166` — dashboard "top links" chip

## Behavior

- Post-create paths (153, 250): only the auto-generated slug exists at creation, so `is_primary` and `!is_custom` return the same row. No behavior change.
- Dashboard rows (1130, 1166): the chip now reflects the user's chosen primary, matching the link detail page and what the redirect serves.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `yarn test` — 864/865 pass; the one failure is an unrelated DNS-lookup hook timeout in `redirect-kv.test.ts`, untouched by this change
- [ ] Manual: set a custom slug as primary on a link, then reload the dashboard and confirm both "recent" and "top" cards show the custom slug

---
_Generated by [Claude Code](https://claude.ai/code/session_015JgkMdpgqKH5D1eFbSxiQj)_