### PR TITLE
Mark the in-progress period as incomplete on click charts

### DIFF
--- a/src/__tests__/unit/big-chart.test.ts
+++ b/src/__tests__/unit/big-chart.test.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { jsx } from "hono/jsx";
+import { BigChart } from "../../components/big-chart";
+import { createTranslateFn } from "../../i18n";
+import type { TimelineRange } from "../../types";
+
+const t = createTranslateFn("en");
+
+function render(values: number[], range: TimelineRange = "30d"): string {
+  return String(jsx(BigChart, { values, range, t, id: "test" }));
+}
+
+describe("BigChart incomplete-period treatment", () => {
+  it("draws the final segment dashed so the partial current period does not read as a real drop", () => {
+    const out = render([10, 20, 30, 40, 5]);
+    expect(out).toContain("stroke-dasharray");
+  });
+
+  it("flags the final point as in-progress via an accessible title", () => {
+    const out = render([10, 20, 30, 40, 5]);
+    expect(out).toContain(t("linkDetail.todayPartial"));
+  });
+
+  it("still labels the final point as today", () => {
+    const out = render([10, 20, 30, 40, 5]);
+    expect(out).toContain(">today<");
+  });
+
+  it("does not draw a dashed connector when there is only one point", () => {
+    const out = render([7]);
+    expect(out).not.toContain("stroke-dasharray");
+    // The lone point is still the current, incomplete period.
+    expect(out).toContain(t("linkDetail.todayPartial"));
+  });
+
+  it("renders the empty-state hint when there are no values", () => {
+    const out = render([]);
+    expect(out).toContain(t("linkDetail.noClickData"));
+    expect(out).not.toContain("stroke-dasharray");
+  });
+});

--- a/src/__tests__/unit/big-chart.test.ts
+++ b/src/__tests__/unit/big-chart.test.ts
@@ -36,6 +36,21 @@ describe("BigChart incomplete-period treatment", () => {
     expect(out).toContain(t("linkDetail.todayPartial"));
   });
 
+  it("omits the gradient area when only one period is complete", () => {
+    // n === 2: a single completed period plus the in-progress point. With one
+    // completed point there is no segment to fill under, so the area would be a
+    // zero-width degenerate path; render nothing and let the dashed connector
+    // carry the in-progress point.
+    const out = render([10, 20]);
+    expect(out).not.toContain("url(#test-grad)");
+    expect(out).toContain("stroke-dasharray");
+  });
+
+  it("fills the gradient area once at least two periods are complete", () => {
+    const out = render([10, 20, 30]);
+    expect(out).toContain("url(#test-grad)");
+  });
+
   it("renders the empty-state hint when there are no values", () => {
     const out = render([]);
     expect(out).toContain(t("linkDetail.noClickData"));

--- a/src/client.ts
+++ b/src/client.ts
@@ -937,13 +937,22 @@ function renderTimeline(data) {
     pts[i] = [x, y];
   }
 
-  var line = '';
-  for (var i = 0; i < n; i++) {
-    line += (i === 0 ? 'M' : 'L') + pts[i][0].toFixed(1) + ',' + pts[i][1].toFixed(1) + ' ';
-  }
-  var lastX = n > 1 ? pad.l + innerW : pts[0][0];
+  // The final bucket is the current, still-accumulating period; draw the complete
+  // periods solid and connect the in-progress point with a dashed segment so the
+  // chart does not always look like it is dropping at the end.
   var baseY = pad.t + innerH;
-  var area = line + 'L' + lastX.toFixed(1) + ',' + baseY + ' L' + pad.l + ',' + baseY + ' Z';
+  var solidLine = '';
+  for (var i = 0; i < n - 1; i++) {
+    solidLine += (i === 0 ? 'M' : 'L') + pts[i][0].toFixed(1) + ',' + pts[i][1].toFixed(1) + ' ';
+  }
+  var area = '';
+  if (n > 1) {
+    area = solidLine + 'L' + pts[n - 2][0].toFixed(1) + ',' + baseY + ' L' + pts[0][0].toFixed(1) + ',' + baseY + ' Z';
+  }
+  var dashLine = '';
+  if (n > 1) {
+    dashLine = 'M' + pts[n - 2][0].toFixed(1) + ',' + pts[n - 2][1].toFixed(1) + ' L' + pts[n - 1][0].toFixed(1) + ',' + pts[n - 1][1].toFixed(1);
+  }
 
   var grid = [0, 0.25, 0.5, 0.75, 1];
   var parts = [];
@@ -960,13 +969,18 @@ function renderTimeline(data) {
     parts.push('<text x="' + (pad.l - 6) + '" y="' + (gy + 3) + '" font-size="9" fill="var(--color-text-subtle)" text-anchor="end" font-family="var(--font-family-mono)">' + fmtNum(val) + '</text>');
   }
 
-  parts.push('<path d="' + area + '" fill="url(#chartGrad)"/>');
-  parts.push('<path d="' + line + '" fill="none" stroke="var(--color-accent)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" vector-effect="non-scaling-stroke"/>');
+  if (area) parts.push('<path d="' + area + '" fill="url(#chartGrad)"/>');
+  if (n > 2) parts.push('<path d="' + solidLine + '" fill="none" stroke="var(--color-accent)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" vector-effect="non-scaling-stroke"/>');
+  if (dashLine) parts.push('<path d="' + dashLine + '" fill="none" stroke="var(--color-accent)" stroke-width="2" stroke-opacity="0.7" stroke-dasharray="4 4" stroke-linejoin="round" stroke-linecap="round" vector-effect="non-scaling-stroke"/>');
 
   var dotInterval = n > 60 ? Math.ceil(n / 10) : (n > 30 ? 5 : (n > 14 ? 3 : 1));
   for (var i = 0; i < n; i++) {
     if (i % dotInterval === 0 || i === n - 1) {
-      parts.push('<circle cx="' + pts[i][0].toFixed(1) + '" cy="' + pts[i][1].toFixed(1) + '" r="2.5" fill="var(--color-accent)" stroke="var(--color-surface-raised)" stroke-width="1.5" vector-effect="non-scaling-stroke"/>');
+      if (i === n - 1) {
+        parts.push('<circle cx="' + pts[i][0].toFixed(1) + '" cy="' + pts[i][1].toFixed(1) + '" r="2.5" fill="var(--color-surface-raised)" stroke="var(--color-accent)" stroke-width="1.5" vector-effect="non-scaling-stroke"><title>' + esc(t('linkDetail.todayPartial')) + '</title></circle>');
+      } else {
+        parts.push('<circle cx="' + pts[i][0].toFixed(1) + '" cy="' + pts[i][1].toFixed(1) + '" r="2.5" fill="var(--color-accent)" stroke="var(--color-surface-raised)" stroke-width="1.5" vector-effect="non-scaling-stroke"/>');
+      }
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -945,8 +945,11 @@ function renderTimeline(data) {
   for (var i = 0; i < n - 1; i++) {
     solidLine += (i === 0 ? 'M' : 'L') + pts[i][0].toFixed(1) + ',' + pts[i][1].toFixed(1) + ' ';
   }
+  // Fill the area only with at least two complete points (a real segment);
+  // a single completed point has nothing to fill under and would produce a
+  // zero-width degenerate path. Matches the solid-line guard below.
   var area = '';
-  if (n > 1) {
+  if (n > 2) {
     area = solidLine + 'L' + pts[n - 2][0].toFixed(1) + ',' + baseY + ' L' + pts[0][0].toFixed(1) + ',' + baseY + ' Z';
   }
   var dashLine = '';

--- a/src/components/big-chart.tsx
+++ b/src/components/big-chart.tsx
@@ -76,7 +76,10 @@ export const BigChart: FC<BigChartProps> = ({ values, range, t, id }) => {
   const solidLine = solidPts
     .map((p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)},${p[1].toFixed(1)}`)
     .join(" ");
-  const area = solidPts.length > 0
+  // Fill the area only when there are at least two complete points (a real
+  // segment); a single completed point has nothing to fill under and would
+  // produce a zero-width degenerate path. Matches the solid-line guard below.
+  const area = solidPts.length > 1
     ? `${solidLine} L${solidPts[solidPts.length - 1][0].toFixed(1)},${baseY} L${solidPts[0][0].toFixed(1)},${baseY} Z`
     : "";
   const dashLine = n > 1

--- a/src/components/big-chart.tsx
+++ b/src/components/big-chart.tsx
@@ -67,10 +67,21 @@ export const BigChart: FC<BigChartProps> = ({ values, range, t, id }) => {
     pts.push([x, y]);
   }
 
-  const line = pts.map((p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)},${p[1].toFixed(1)}`).join(" ");
-  const lastX = n > 1 ? PAD.l + innerW : pts[0][0];
+  // The final point is the current, still-accumulating period (today, or the
+  // current hour/week/month for other ranges). Drawing it solid makes every chart
+  // look like it is dropping at the end. Render the run of complete periods solid
+  // and connect the in-progress point with a dashed segment and a hollow marker.
   const baseY = PAD.t + innerH;
-  const area = `${line} L${lastX.toFixed(1)},${baseY} L${PAD.l},${baseY} Z`;
+  const solidPts = pts.slice(0, n - 1);
+  const solidLine = solidPts
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p[0].toFixed(1)},${p[1].toFixed(1)}`)
+    .join(" ");
+  const area = solidPts.length > 0
+    ? `${solidLine} L${solidPts[solidPts.length - 1][0].toFixed(1)},${baseY} L${solidPts[0][0].toFixed(1)},${baseY} Z`
+    : "";
+  const dashLine = n > 1
+    ? `M${pts[n - 2][0].toFixed(1)},${pts[n - 2][1].toFixed(1)} L${pts[n - 1][0].toFixed(1)},${pts[n - 1][1].toFixed(1)}`
+    : "";
 
   const grid = [0, 0.25, 0.5, 0.75, 1];
   const dotInterval = n > 60 ? Math.ceil(n / 10) : n > 30 ? 5 : n > 14 ? 3 : 1;
@@ -112,18 +123,48 @@ export const BigChart: FC<BigChartProps> = ({ values, range, t, id }) => {
           </g>
         );
       })}
-      <path d={area} fill={`url(#${gradId})`} />
-      <path
-        d={line}
-        fill="none"
-        stroke="var(--color-accent)"
-        stroke-width="2"
-        stroke-linejoin="round"
-        stroke-linecap="round"
-        vector-effect="non-scaling-stroke"
-      />
-      {pts.map((p, i) =>
-        i % dotInterval === 0 || i === n - 1 ? (
+      {area ? <path d={area} fill={`url(#${gradId})`} /> : null}
+      {solidPts.length > 1 ? (
+        <path
+          d={solidLine}
+          fill="none"
+          stroke="var(--color-accent)"
+          stroke-width="2"
+          stroke-linejoin="round"
+          stroke-linecap="round"
+          vector-effect="non-scaling-stroke"
+        />
+      ) : null}
+      {dashLine ? (
+        <path
+          d={dashLine}
+          fill="none"
+          stroke="var(--color-accent)"
+          stroke-width="2"
+          stroke-opacity="0.7"
+          stroke-dasharray="4 4"
+          stroke-linejoin="round"
+          stroke-linecap="round"
+          vector-effect="non-scaling-stroke"
+        />
+      ) : null}
+      {pts.map((p, i) => {
+        const isLast = i === n - 1;
+        if (!(i % dotInterval === 0 || isLast)) return null;
+        return isLast ? (
+          <circle
+            key={`dot-${i}`}
+            cx={p[0].toFixed(1)}
+            cy={p[1].toFixed(1)}
+            r="2.5"
+            fill="var(--color-surface-raised)"
+            stroke="var(--color-accent)"
+            stroke-width="1.5"
+            vector-effect="non-scaling-stroke"
+          >
+            <title>{t("linkDetail.todayPartial")}</title>
+          </circle>
+        ) : (
           <circle
             key={`dot-${i}`}
             cx={p[0].toFixed(1)}
@@ -134,8 +175,8 @@ export const BigChart: FC<BigChartProps> = ({ values, range, t, id }) => {
             stroke-width="1.5"
             vector-effect="non-scaling-stroke"
           />
-        ) : null,
-      )}
+        );
+      })}
       {pts.map((p, i) =>
         i % dotInterval === 0 || i === n - 1 ? (
           <text

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -95,6 +95,7 @@ const en = {
   "linkDetail.totalClicks": "total clicks",
   "linkDetail.clicksInRange": "clicks in selected range",
   "linkDetail.today": "today",
+  "linkDetail.todayPartial": "today (in progress)",
   "linkDetail.avgPerDay": "Avg / day",
   "linkDetail.createdOn": "Created",
   "linkDetail.neverExpires": "Never expires",

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -98,6 +98,7 @@ const id: Translations = {
   "linkDetail.totalClicks": "total klik",
   "linkDetail.clicksInRange": "klik dalam rentang terpilih",
   "linkDetail.today": "hari ini",
+  "linkDetail.todayPartial": "hari ini (berjalan)",
   "linkDetail.avgPerDay": "Rata-rata / hari",
   "linkDetail.createdOn": "Dibuat",
   "linkDetail.neverExpires": "Tidak pernah kedaluwarsa",

--- a/src/i18n/sv.ts
+++ b/src/i18n/sv.ts
@@ -98,6 +98,7 @@ const sv: Translations = {
   "linkDetail.totalClicks": "totalt antal klick",
   "linkDetail.clicksInRange": "klick i vald period",
   "linkDetail.today": "idag",
+  "linkDetail.todayPartial": "idag (pågår)",
   "linkDetail.avgPerDay": "Snitt / dag",
   "linkDetail.createdOn": "Skapad",
   "linkDetail.neverExpires": "Går aldrig ut",


### PR DESCRIPTION
## Why

The "Clicks over time" charts always hook downward at the end:

The final point is the current, still-accumulating period: **today** on daily ranges (7d/30d/90d), the current hour on 24h, the current week on 1y, and the current month on `all`. That period only has clicks counted so far, so it almost always sits below a full period and reads as a real drop when it is just "the day isn't over yet."

## What

Keep the in-progress point visible, but render it so it no longer looks like a decline:

- The run of **complete** periods stays a solid line with the gradient fill.
- The **in-progress** point is connected by a **dashed** segment, gets a **hollow** marker, and carries a `today (in progress)` tooltip (`<title>`).

This is done purely at the render layer, in both chart implementations:

- `src/components/big-chart.tsx` — server-rendered chart used by the dashboard and bundle detail.
- `src/client.ts` `renderTimeline` — client-rendered chart on the link detail page.

The data layer (`ClickRepository.getTimeline` / `getSparkline`) is untouched, so today's clicks remain in the series and the existing bucket-count contract and its tests stay green. I chose this over physically dropping today (which would hide today's activity and break those data-layer tests, which `CLAUDE.md` forbids editing).

## i18n

Added `linkDetail.todayPartial` to all three locales (en/id/sv).

## Tests

New `src/__tests__/unit/big-chart.test.ts` covers: the dashed final segment, the in-progress title, the preserved `today` label, the single-point edge case (no dashed connector), and the empty state. Full suite: 958 passing; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TKFX8qZBoKHjaNozTxFik

---
_Generated by [Claude Code](https://claude.ai/code/session_017TKFX8qZBoKHjaNozTxFik)_