### PR TITLE
fix: dashboard Error 1102 (CPU limit) via bulk delta enrichment

### DIFF
--- a/src/__tests__/repository/click-repository.test.ts
+++ b/src/__tests__/repository/click-repository.test.ts
@@ -262,6 +262,46 @@ describe("ClickRepository.getDashboardStats", () => {
   });
 });
 
+describe("ClickRepository.getDashboardStats query scaling", () => {
+  // Wrap a D1Database so every .prepare() call increments a counter, while
+  // delegating all behavior to the real binding.
+  function countingDb(db: D1Database, counter: { n: number }): D1Database {
+    return new Proxy(db, {
+      get(target, prop, receiver) {
+        if (prop === "prepare") {
+          return (sql: string) => {
+            counter.n++;
+            return (target as unknown as D1Database).prepare(sql);
+          };
+        }
+        const v = Reflect.get(target, prop, receiver);
+        return typeof v === "function" ? v.bind(target) : v;
+      },
+    }) as unknown as D1Database;
+  }
+
+  async function seedLinks(n: number, offset: number) {
+    for (let i = offset; i < offset + n; i++) {
+      const link = await LinkRepository.create(env.DB, { url: `https://example.com/p${i}`, slug: `s${i}` });
+      await ClickRepository.record(env.DB, link.slugs[0].slug, { country: "US" });
+    }
+  }
+
+  it("issues a query count that does not grow with the number of links", async () => {
+    await seedLinks(10, 0);
+    const small = { n: 0 };
+    await ClickRepository.getDashboardStats(countingDb(env.DB, small), "30d");
+
+    await seedLinks(40, 10); // 50 links total
+    const large = { n: 0 };
+    await ClickRepository.getDashboardStats(countingDb(env.DB, large), "30d");
+
+    // Per-link delta fan-out makes the count scale with link count; the
+    // dashboard must enrich deltas in a bounded number of grouped queries.
+    expect(large.n).toBe(small.n);
+  });
+});
+
 describe("ClickRepository.getStats with range filter", () => {
   it("returns all clicks when range is undefined", async () => {
     const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });

--- a/src/db/click-repository.ts
+++ b/src/db/click-repository.ts
@@ -613,27 +613,6 @@ export class ClickRepository {
 
 
   /**
-   * Enriches links with delta_pct for the selected range.
-   * Done in one query per link to keep the dashboard lightweight.
-   */
-  static async attachLinkDeltas(
-    db: D1Database,
-    links: LinkWithSlugs[],
-    range: TimelineRange,
-    now?: number,
-    filters?: ClickFilters,
-  ): Promise<LinkWithSlugs[]> {
-    if (range === "all") return links;
-    const results = await Promise.all(
-      links.map(async (link) => {
-        const { current, previous } = await this.getPeriodClicks(db, range, now, link.id, filters);
-        return { ...link, delta_pct: computeDelta(current, previous) };
-      }),
-    );
-    return results;
-  }
-
-  /**
    * Bulk-enriches links with delta_pct using two grouped queries regardless
    * of list size. Safe for the listings page where per-link queries would
    * exceed D1's subrequest limit.

--- a/src/db/click-repository.ts
+++ b/src/db/click-repository.ts
@@ -735,7 +735,7 @@ export class ClickRepository {
       this.getClickedLinksPeriods(db, range, ts, filters),
     ]);
 
-    const withDeltas = await this.attachLinkDeltas(db, recentLinks, range, ts, filters);
+    const withDeltas = await this.attachLinkDeltasBulk(db, recentLinks, range, ts, filters);
     const linkById = new Map(withDeltas.map((l) => [l.id, l]));
     const topLinks = (topLinkRows.results ?? [])
       .map((r) => {


### PR DESCRIPTION
## Problem

`GET /_/admin/dashboard` returns **Error 1102 (Worker exceeded CPU time limit)** on the Workers free plan (10 ms CPU/invocation). Confirmed from observability: the failing Ray ID resolves to the dashboard GET plus a "Worker exceeded CPU time limit" event in the same invocation.

## Root cause

`ClickRepository.getDashboardStats` enriched links with click deltas via the per-link `attachLinkDeltas`, which issues **two COUNT queries per link**. Measured query count for the dashboard was `2N + 18`:

| Links (N) | Dashboard queries |
|---|---|
| 5 | 28 |
| 25 | 68 |
| 87 (prod) | **192** |

Marshalling ~192 D1 results in a single invocation pushed the request past the 10 ms CPU ceiling. Data volume is not the cause (87 links / 167 slugs / 4,244 clicks).

## Fix

Swap to the existing `attachLinkDeltasBulk`, which computes every link's current and previous window in **two grouped queries** regardless of list size. The links listing page already used it; the dashboard now matches.

| | Before | After |
|---|---|---|
| Dashboard queries @ 87 links | 192 | **20** |
| Scales with catalog | yes (`2N+18`) | **no (constant)** |

## Tests

- Added a regression test asserting the dashboard query count stays constant as link count grows (10 vs 50 links → equal). Fails before the swap (118 vs 38), passes after (20 vs 20).
- Full suite green: 954/954.

## Notes

Separate future-scalability item filed as #17 (the O(links × slugs) assembly in `LinkRepository.list`); not part of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
