### PR TITLE
fix: disabled links redirect for up to one second after disabling

### DIFF
--- a/src/__tests__/integration/expiration-flow.test.ts
+++ b/src/__tests__/integration/expiration-flow.test.ts
@@ -22,7 +22,9 @@ function req(slug: string): Request {
 // turns the case into expires_at < now, which the pre-fix strict-`<` code
 // also 404s, making the regression test pass against the bug it guards.
 async function alignToSecondStart(): Promise<void> {
-  await new Promise((r) => setTimeout(r, 1000 - (Date.now() % 1000)));
+  // The outer % 1000 collapses the delay to 0 when Date.now() already sits on a
+  // boundary, sidestepping a needless full-second sleep (1000 - 0 = 1000).
+  await new Promise((r) => setTimeout(r, (1000 - (Date.now() % 1000)) % 1000));
 }
 
 beforeAll(applyMigrations);

--- a/src/__tests__/integration/expiration-flow.test.ts
+++ b/src/__tests__/integration/expiration-flow.test.ts
@@ -70,6 +70,24 @@ describe("expires_at flow", () => {
   });
 });
 
+describe("expires_at = now boundary", () => {
+  it("treats expires_at equal to the current second as expired (disable takes effect immediately)", async () => {
+    // LinkRepository.disable() sets expires_at = Math.floor(Date.now() / 1000).
+    // The redirect handler must treat that as expired rather than waiting an
+    // extra second before the strict-less-than check turns true.
+    const slug = "exact-now";
+    await LinkRepository.create(env.DB, {
+      url: "https://example.com/exact-now",
+      slug,
+      expiresAt: Math.floor(Date.now() / 1000),
+      createdBy: DEV_IDENTITY,
+    });
+    await SlugCache.delete(env.SLUG_KV, slug);
+    const res = await SELF.fetch(req(slug));
+    expect(res.status).toBe(404);
+  });
+});
+
 describe("expires_at = 0 boundary", () => {
   it("treats 0 as an epoch timestamp (expired), not as no expiry", async () => {
     // The Link schema documents "null means no expiry". A stored 0 is a real

--- a/src/__tests__/integration/expiration-flow.test.ts
+++ b/src/__tests__/integration/expiration-flow.test.ts
@@ -13,6 +13,18 @@ function req(slug: string): Request {
   return new Request(`https://shrtnr.test/${slug}`, { redirect: "manual" });
 }
 
+// Park execution just after a fresh Unix-second boundary so the create/fetch
+// that follow land inside the same second as the captured timestamp. The
+// redirect handler computes its own Math.floor(Date.now() / 1000) in the
+// Worker isolate, a clock the test process can not freeze, so the boundary
+// case (expires_at === handler's now) is only reliably exercised when both
+// readings fall in the same second. Without the alignment a mid-test tick
+// turns the case into expires_at < now, which the pre-fix strict-`<` code
+// also 404s, making the regression test pass against the bug it guards.
+async function alignToSecondStart(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 1000 - (Date.now() % 1000)));
+}
+
 beforeAll(applyMigrations);
 beforeEach(resetData);
 
@@ -76,10 +88,14 @@ describe("expires_at = now boundary", () => {
     // The redirect handler must treat that as expired rather than waiting an
     // extra second before the strict-less-than check turns true.
     const slug = "exact-now";
+    // Capture the second at the top of a fresh tick, then create + evict + fetch
+    // inside that same second so the handler reads expires_at === its own now.
+    await alignToSecondStart();
+    const nowSec = Math.floor(Date.now() / 1000);
     await LinkRepository.create(env.DB, {
       url: "https://example.com/exact-now",
       slug,
-      expiresAt: Math.floor(Date.now() / 1000),
+      expiresAt: nowSec,
       createdBy: DEV_IDENTITY,
     });
     await SlugCache.delete(env.SLUG_KV, slug);

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -40,7 +40,7 @@ export async function handleRedirect(
 
   // 4. Check expired. Null-aware, not truthy: null means no expiry, but a
   // stored 0 is a real epoch timestamp and must count as expired.
-  if (entry.expires_at != null && entry.expires_at < Math.floor(Date.now() / 1000)) {
+  if (entry.expires_at != null && entry.expires_at <= Math.floor(Date.now() / 1000)) {
     return notFoundResponse();
   }
 


### PR DESCRIPTION
## What was wrong

`LinkRepository.disable()` stamps `expires_at = Math.floor(Date.now() / 1000)` (the current Unix second). `handleRedirect` checked:

```typescript
if (entry.expires_at != null && entry.expires_at < Math.floor(Date.now() / 1000)) {
```

Within the same wall-clock second, `now < now` is false, so a just-disabled link still issues a 301 redirect for up to one second after the API call returns. Any request that arrives in that window — including automated tests that call the redirect endpoint immediately after calling the disable endpoint — gets through to the destination.

## Impact

- Disable-link has a one-second enforcement gap on every call.
- Callers that programmatically disable then immediately verify (integration tests, health checks, client apps) may observe the link as still active and draw the wrong conclusion.
- KV cache does not hide the bug: `disableLink` evicts the KV entry, so subsequent requests fall through to D1 and hit the same comparison.

## Fix

Change `<` to `<=` in `src/redirect.ts`:

```typescript
if (entry.expires_at != null && entry.expires_at <= Math.floor(Date.now() / 1000)) {
```

A link whose `expires_at` equals the current second is now immediately treated as expired, matching the natural reading of "expires AT this timestamp."

The `<=` operator is also the correct boundary for future-set expiry: a link set to expire at second T should be inaccessible at second T, not one second later.

## Regression test

`src/__tests__/integration/expiration-flow.test.ts` — new `expires_at = now boundary` describe block:

1. Creates a link with `expiresAt = Math.floor(Date.now() / 1000)`.
2. Evicts KV so the redirect handler falls through to D1.
3. Asserts the redirect returns 404.

This test fails on the old code (returns 301) and passes on the fixed code.

## Test run

```
Test Files  53 passed (53)
      Tests  972 passed (972)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPoM5JscDtfPRMJvVYhC6t)_