### PR TITLE
Redesign the API keys page to onboard developers (quick start + SDKs)

### DIFF
--- a/src/__tests__/page/keys-page.test.ts
+++ b/src/__tests__/page/keys-page.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { env, SELF } from "cloudflare:test";
+import { applyMigrations, resetData } from "../setup";
+
+function makeJwt(email: string): string {
+  const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const body = btoa(JSON.stringify({ email }));
+  return `${header}.${body}.fakesig`;
+}
+
+const AUTH_HEADER = { "Cf-Access-Jwt-Assertion": makeJwt("test@example.com") };
+
+function authed(path: string, init?: RequestInit): Request {
+  return new Request(`https://shrtnr.test${path}`, {
+    ...init,
+    headers: { ...AUTH_HEADER, ...(init?.headers ?? {}) },
+  });
+}
+
+// Seeds an api_keys row for the requesting identity so the table renders a row.
+async function seedApiKey(identity = "test@example.com"): Promise<string> {
+  const raw = `sk_${crypto.randomUUID().replace(/-/g, "")}`;
+  const prefix = raw.slice(0, 7);
+  const hashBuf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(raw));
+  const hash = Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  await env.DB.prepare(
+    "INSERT INTO api_keys (identity, title, key_prefix, key_hash, scope, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+  )
+    .bind(identity, "Test key", prefix, hash, "create", Math.floor(Date.now() / 1000))
+    .run();
+  return raw;
+}
+
+beforeAll(applyMigrations);
+beforeEach(resetData);
+
+async function fetchKeysHtml(): Promise<string> {
+  const res = await SELF.fetch(authed("/_/admin/keys"));
+  expect(res.status).toBe(200);
+  return res.text();
+}
+
+describe("Keys page header", () => {
+  it("renders the New key action wired to the create modal", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).toContain("New key");
+    expect(html).toContain("showCreateKeyModal()");
+  });
+
+  it("drops the standalone count line and toolbar", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).not.toContain('class="toolbar-count"');
+    expect(html).not.toContain('class="toolbar"');
+  });
+});
+
+describe("Keys page auth banner", () => {
+  it("renders the auth guidance with an inline Authorization code element", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).toContain("Authenticate requests with a key");
+    expect(html).toContain("<code>Authorization</code>");
+  });
+
+  it("links to the API documentation", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).toContain('href="/_/api/docs"');
+  });
+});
+
+describe("Keys page quick start", () => {
+  it("renders a copyable curl example against the live request origin", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).toContain("https://shrtnr.test/_/api/links");
+    expect(html).toContain("Bearer");
+  });
+
+  it("wires the code block to the clipboard copy helper", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).toContain('id="quickstart-curl"');
+    // Hono escapes the single quotes in the onclick attribute to &#39;; the
+    // browser decodes them, so the assertion tolerates either form.
+    expect(html).toMatch(/copyCodeBlock\((?:'|&#39;)quickstart-curl(?:'|&#39;)\)/);
+  });
+});
+
+describe("Keys page SDK card", () => {
+  it("lists the three published SDKs with package coordinates", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).toContain("@oddbit/shrtnr");
+    expect(html).toContain("PyPI: shrtnr");
+    expect(html).toContain("pub.dev: shrtnr");
+  });
+
+  it("links each SDK to its registry page", async () => {
+    const html = await fetchKeysHtml();
+    expect(html).toContain("shrtnr-npm-app");
+    expect(html).toContain("shrtnr-pypi-app");
+    expect(html).toContain("shrtnr-pub-app");
+  });
+});
+
+describe("Keys page table", () => {
+  it("masks the key prefix with bullets instead of a bare truncation", async () => {
+    const raw = await seedApiKey();
+    const prefix = raw.slice(0, 7);
+    const html = await fetchKeysHtml();
+    expect(html).toContain(`${prefix}••••••`);
+    expect(html).not.toContain(`${prefix}&hellip;`);
+  });
+
+  it("keeps the delete action for each key", async () => {
+    await seedApiKey();
+    const html = await fetchKeysHtml();
+    expect(html).toContain("deleteKey(");
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -89,9 +89,10 @@ function copyUrl(slug) {
 
 function copyCodeBlock(id) {
   var el = document.getElementById(id);
-  if (!el) return;
-  navigator.clipboard.writeText(el.textContent);
-  toast(t('client.codeCopied'));
+  if (!el || !navigator.clipboard) return;
+  navigator.clipboard.writeText(el.textContent).then(function() {
+    toast(t('client.codeCopied'));
+  }, function() {});
 }
 
 // ---- Mobile drawer ----

--- a/src/client.ts
+++ b/src/client.ts
@@ -90,7 +90,7 @@ function copyUrl(slug) {
 function copyCodeBlock(id) {
   var el = document.getElementById(id);
   if (!el || !navigator.clipboard) return;
-  navigator.clipboard.writeText(el.textContent).then(function() {
+  navigator.clipboard.writeText(el.textContent || '').then(function() {
     toast(t('client.codeCopied'));
   }, function() {});
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -87,6 +87,13 @@ function copyUrl(slug) {
   toast(t('client.copied', {url: url}));
 }
 
+function copyCodeBlock(id) {
+  var el = document.getElementById(id);
+  if (!el) return;
+  navigator.clipboard.writeText(el.textContent);
+  toast(t('client.codeCopied'));
+}
+
 // ---- Mobile drawer ----
 function toggleDrawer() {
   var s = document.querySelector('.sidebar');

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -205,15 +205,17 @@ const en = {
   "bundles.accent.purple": "Purple",
 
   // API Keys
-  "keys.title": "API Keys",
+  "keys.title": "API keys",
   "keys.subtitle": "Manage programmatic access to the shortener API",
-  "keys.docsNote": "Use API keys to authenticate API requests:",
   "keys.docsLink": "API documentation",
-  "keys.count": "{count} key",
-  "keys.countPlural": "{count} keys",
-  "keys.newKey": "New Key",
+  "keys.authBanner": "Authenticate requests with a key in the {header} header.",
+  "keys.quickStartTitle": "Quick start",
+  "keys.quickStartHint": "List your links with a Bearer key.",
+  "keys.sdkCardTitle": "Or use an SDK",
+  "keys.copyCommand": "Copy command",
+  "keys.newKey": "New key",
   "keys.empty":
-    "No API keys yet. Use the + New Key button above to enable programmatic access.",
+    "No API keys yet. Use the + New key button above to enable programmatic access.",
   "keys.colTitle": "Title",
   "keys.colKey": "Key",
   "keys.colScope": "Scope",
@@ -342,6 +344,7 @@ const en = {
   "client.copy": "Copy",
   "client.done": "Done",
   "client.apiKeyCopied": "API key copied",
+  "client.codeCopied": "Command copied",
   "client.confirmDeleteKey":
     'Delete API key "{title}"? This cannot be undone.',
   "client.keyDeleted": "Key deleted",

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -210,13 +210,15 @@ const id: Translations = {
   // API Keys
   "keys.title": "Kunci API",
   "keys.subtitle": "Kelola akses programatik ke API pemerpendek",
-  "keys.docsNote": "Gunakan kunci API untuk mengautentikasi permintaan API:",
   "keys.docsLink": "Dokumentasi API",
-  "keys.count": "{count} kunci",
-  "keys.countPlural": "{count} kunci",
-  "keys.newKey": "Kunci Baru",
+  "keys.authBanner": "Autentikasi permintaan dengan kunci di header {header}.",
+  "keys.quickStartTitle": "Mulai cepat",
+  "keys.quickStartHint": "Cantumkan tautan Anda dengan kunci Bearer.",
+  "keys.sdkCardTitle": "Atau gunakan SDK",
+  "keys.copyCommand": "Salin perintah",
+  "keys.newKey": "Kunci baru",
   "keys.empty":
-    "Belum ada kunci API. Gunakan tombol + Kunci Baru di atas untuk mengaktifkan akses programatik.",
+    "Belum ada kunci API. Gunakan tombol + Kunci baru di atas untuk mengaktifkan akses programatik.",
   "keys.colTitle": "Judul",
   "keys.colKey": "Kunci",
   "keys.colScope": "Cakupan",
@@ -346,6 +348,7 @@ const id: Translations = {
   "client.copy": "Salin",
   "client.done": "Selesai",
   "client.apiKeyCopied": "Kunci API disalin",
+  "client.codeCopied": "Perintah disalin",
   "client.confirmDeleteKey":
     'Hapus kunci API "{title}"? Tindakan ini tidak dapat dibatalkan.',
   "client.keyDeleted": "Kunci dihapus",

--- a/src/i18n/sv.ts
+++ b/src/i18n/sv.ts
@@ -210,10 +210,12 @@ const sv: Translations = {
   // API Keys
   "keys.title": "API-nycklar",
   "keys.subtitle": "Hantera programmatisk åtkomst till förkortnings-API:et",
-  "keys.docsNote": "Använd API-nycklar för att autentisera API-förfrågningar:",
   "keys.docsLink": "API-dokumentation",
-  "keys.count": "{count} nyckel",
-  "keys.countPlural": "{count} nycklar",
+  "keys.authBanner": "Autentisera förfrågningar med en nyckel i {header}-huvudet.",
+  "keys.quickStartTitle": "Kom igång",
+  "keys.quickStartHint": "Lista dina länkar med en Bearer-nyckel.",
+  "keys.sdkCardTitle": "Eller använd ett SDK",
+  "keys.copyCommand": "Kopiera kommando",
   "keys.newKey": "Ny nyckel",
   "keys.empty":
     "Inga API-nycklar ännu. Använd knappen + Ny nyckel ovan för att aktivera programmatisk åtkomst.",
@@ -346,6 +348,7 @@ const sv: Translations = {
   "client.copy": "Kopiera",
   "client.done": "Klar",
   "client.apiKeyCopied": "API-nyckel kopierad",
+  "client.codeCopied": "Kommando kopierat",
   "client.confirmDeleteKey":
     'Ta bort API-nyckel "{title}"? Detta kan inte ångras.',
   "client.keyDeleted": "Nyckel borttagen",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -306,9 +306,10 @@ app.get("/_/admin/keys", async (c) => {
   const { theme, t, lang, translations } = await getPageData(c, identity);
   const keysResult = await listAllApiKeys(c.env, identity);
   const keys = keysResult.ok ? keysResult.data : [];
+  const origin = new URL(c.req.url).origin;
   return c.html(
     <Layout active="keys" theme={theme} t={t} lang={lang} translations={translations}>
-      <KeysPage keys={keys as any} t={t} lang={lang} />
+      <KeysPage keys={keys as any} t={t} lang={lang} origin={origin} />
     </Layout>,
   );
 });

--- a/src/pages/keys.tsx
+++ b/src/pages/keys.tsx
@@ -35,9 +35,13 @@ type Props = {
 };
 
 export const KeysPage: FC<Props> = ({ keys, t, lang, origin }) => {
-  // Split the banner copy around the {header} token so "Authorization" renders
-  // as an inline code element while word order stays translator-controlled.
-  const [bannerBefore, bannerAfter = ""] = t("keys.authBanner").split("{header}");
+  // Render "Authorization" as inline code by splitting the banner copy around
+  // the {header} token, keeping word order translator-controlled. Only split
+  // when the token is present so a locale that drops it still reads cleanly.
+  const authBanner = t("keys.authBanner");
+  const authParts = authBanner.includes("{header}")
+    ? authBanner.split("{header}")
+    : null;
   const curl = `curl ${origin}/_/api/links \\\n  -H "Authorization: Bearer sk_..."`;
 
   return (
@@ -56,9 +60,15 @@ export const KeysPage: FC<Props> = ({ keys, t, lang, origin }) => {
         <span class="auth-banner-text">
           <span class="icon">info</span>
           <span>
-            {bannerBefore}
-            <code>Authorization</code>
-            {bannerAfter}
+            {authParts ? (
+              <>
+                {authParts[0]}
+                <code>Authorization</code>
+                {authParts.slice(1).join("{header}")}
+              </>
+            ) : (
+              authBanner
+            )}
           </span>
         </span>
         <a class="auth-banner-link" href="/_/api/docs" target="_blank" rel="noopener">

--- a/src/pages/keys.tsx
+++ b/src/pages/keys.tsx
@@ -4,6 +4,10 @@
 import type { FC } from "hono/jsx";
 import type { TranslateFn } from "../i18n";
 import { escHtml } from "../escape";
+import { SdkList } from "./sdk-list";
+
+// Bullets that stand in for the redacted tail of a key prefix, e.g. sk_84cc••••••.
+const KEY_MASK = "••••••";
 
 function formatDate(ts: number, lang: string): string {
   const d = new Date(ts * 1000);
@@ -27,33 +31,63 @@ type Props = {
   keys: ApiKey[];
   t: TranslateFn;
   lang: string;
+  origin: string;
 };
 
-export const KeysPage: FC<Props> = ({ keys, t, lang }) => {
-  const countKey = keys.length !== 1 ? "keys.countPlural" : "keys.count";
+export const KeysPage: FC<Props> = ({ keys, t, lang, origin }) => {
+  // Split the banner copy around the {header} token so "Authorization" renders
+  // as an inline code element while word order stays translator-controlled.
+  const [bannerBefore, bannerAfter = ""] = t("keys.authBanner").split("{header}");
+  const curl = `curl ${origin}/_/api/links \\\n  -H "Authorization: Bearer sk_..."`;
 
   return (
     <>
-      <div class="page-header">
-        <div class="page-title">{t("keys.title")}</div>
-        <div class="page-subtitle">
-          {t("keys.subtitle")}
-        </div>
-        <div class="page-note">
-          {t("keys.docsNote")}{" "}
-          <a href="/_/api/docs">
-            {t("keys.docsLink")}
-          </a>
-        </div>
-      </div>
-
-      <div class="toolbar">
-        <div class="toolbar-count">
-          {t(countKey as any, { count: keys.length })}
+      <div class="keys-page-header">
+        <div class="page-header">
+          <div class="page-title">{t("keys.title")}</div>
+          <div class="page-subtitle">{t("keys.subtitle")}</div>
         </div>
         <button class="btn btn-primary" onclick="showCreateKeyModal()">
           <span class="icon">add</span> {t("keys.newKey")}
         </button>
+      </div>
+
+      <div class="auth-banner">
+        <span class="auth-banner-text">
+          <span class="icon">info</span>
+          <span>
+            {bannerBefore}
+            <code>Authorization</code>
+            {bannerAfter}
+          </span>
+        </span>
+        <a class="auth-banner-link" href="/_/api/docs" target="_blank" rel="noopener">
+          {t("keys.docsLink")} <span class="icon">open_in_new</span>
+        </a>
+      </div>
+
+      <div class="bento">
+        <div class="bento-card span-2">
+          <div class="bento-label">{t("keys.quickStartTitle")}</div>
+          <div class="quick-start-hint">{t("keys.quickStartHint")}</div>
+          <div class="code-block">
+            <button
+              class="btn-icon code-block-copy"
+              onclick="copyCodeBlock('quickstart-curl')"
+              aria-label={t("keys.copyCommand")}
+              title={t("keys.copyCommand")}
+            >
+              <span class="icon">content_copy</span>
+            </button>
+            <pre>
+              <code id="quickstart-curl">{curl}</code>
+            </pre>
+          </div>
+        </div>
+        <div class="bento-card">
+          <div class="bento-label">{t("keys.sdkCardTitle")}</div>
+          <SdkList t={t} />
+        </div>
       </div>
 
       {keys.length === 0 ? (
@@ -84,7 +118,7 @@ export const KeysPage: FC<Props> = ({ keys, t, lang }) => {
                     <tr>
                       <td data-label={t("keys.colTitle")} class="col-title">{k.title}</td>
                       <td data-label={t("keys.colKey")}>
-                        <span class="col-key-prefix">{k.key_prefix}&hellip;</span>
+                        <span class="col-key-mask">{k.key_prefix}{KEY_MASK}</span>
                       </td>
                       <td data-label={t("keys.colScope")}>
                         {scopes.map((s) => (
@@ -96,7 +130,10 @@ export const KeysPage: FC<Props> = ({ keys, t, lang }) => {
                       </td>
                       <td data-label={t("keys.colLastUsed")} class="col-last-used">
                         {k.last_used_at ? (
-                          formatDate(k.last_used_at, lang)
+                          <span class="col-last-used-cell">
+                            <span class="icon">schedule</span>
+                            {formatDate(k.last_used_at, lang)}
+                          </span>
                         ) : (
                           <span class="col-never">{t("keys.never")}</span>
                         )}

--- a/src/pages/sdk-list.tsx
+++ b/src/pages/sdk-list.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FC } from "hono/jsx";
+import type { TranslateFn } from "../i18n";
+
+// The three published SDKs, sourced once here so the keys page and the
+// settings page never drift apart. Package coordinates live in the shared
+// `settings.sdk*` i18n strings.
+const SDKS = [
+  { href: "https://oddb.it/shrtnr-npm-app", lang: "settings.sdkTsLang", pkg: "settings.sdkTsPkg" },
+  { href: "https://oddb.it/shrtnr-pypi-app", lang: "settings.sdkPythonLang", pkg: "settings.sdkPythonPkg" },
+  { href: "https://oddb.it/shrtnr-pub-app", lang: "settings.sdkDartLang", pkg: "settings.sdkDartPkg" },
+] as const;
+
+type Props = {
+  t: TranslateFn;
+};
+
+export const SdkList: FC<Props> = ({ t }) => (
+  <ul class="integration-sdk-list">
+    {SDKS.map((sdk) => (
+      <li>
+        <a href={sdk.href} target="_blank" rel="noopener" class="integration-sdk-link">
+          <span class="integration-sdk-lang">{t(sdk.lang)}</span>
+          <span class="integration-sdk-pkg">{t(sdk.pkg)}</span>
+          <span class="icon">open_in_new</span>
+        </a>
+      </li>
+    ))}
+  </ul>
+);

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -8,6 +8,7 @@ import { SUPPORTED_LANGUAGES } from "../i18n";
 import { fmtNumber } from "../i18n/format";
 import { RANDOM_CHARSET } from "../slugs";
 import { MIN_SLUG_LENGTH } from "../constants";
+import { SdkList } from "./sdk-list";
 
 const RANGE_OPTIONS: TimelineRange[] = ["24h", "7d", "30d", "90d", "1y", "all"];
 
@@ -206,44 +207,7 @@ export const SettingsPage: FC<Props> = ({ theme, slugLength, lang, defaultRange,
               <span class="integration-card-title">{t("settings.sdksTitle")}</span>
             </div>
             <div class="integration-card-desc">{t("settings.sdksDesc")}</div>
-            <ul class="integration-sdk-list">
-              <li>
-                <a
-                  href="https://oddb.it/shrtnr-npm-app"
-                  target="_blank"
-                  rel="noopener"
-                  class="integration-sdk-link"
-                >
-                  <span class="integration-sdk-lang">{t("settings.sdkTsLang")}</span>
-                  <span class="integration-sdk-pkg">{t("settings.sdkTsPkg")}</span>
-                  <span class="icon">open_in_new</span>
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://oddb.it/shrtnr-pypi-app"
-                  target="_blank"
-                  rel="noopener"
-                  class="integration-sdk-link"
-                >
-                  <span class="integration-sdk-lang">{t("settings.sdkPythonLang")}</span>
-                  <span class="integration-sdk-pkg">{t("settings.sdkPythonPkg")}</span>
-                  <span class="icon">open_in_new</span>
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://oddb.it/shrtnr-pub-app"
-                  target="_blank"
-                  rel="noopener"
-                  class="integration-sdk-link"
-                >
-                  <span class="integration-sdk-lang">{t("settings.sdkDartLang")}</span>
-                  <span class="integration-sdk-pkg">{t("settings.sdkDartPkg")}</span>
-                  <span class="icon">open_in_new</span>
-                </a>
-              </li>
-            </ul>
+            <SdkList t={t} />
           </div>
           <a
             href="/_/api/docs#tag/links"

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -617,8 +617,32 @@ select.form-input { appearance: none; -webkit-appearance: none; padding-right: 2
 .keys-table td.col-title { font-weight: 600; }
 .keys-table td.col-date { color: var(--color-text-muted); font-size: 0.8rem; }
 .keys-table td.col-last-used { font-size: 0.8rem; }
-.keys-table .col-key-prefix { font-family: var(--font-family-mono); font-size: 0.8rem; color: var(--color-text-muted); }
-.keys-table .col-never { color: var(--color-text-muted); }
+.keys-table .col-key-mask { font-family: var(--font-family-mono); font-size: 0.8rem; color: var(--color-text-muted); letter-spacing: 0.04em; }
+.keys-table .col-last-used-cell { display: inline-flex; align-items: center; gap: 0.4rem; }
+.keys-table .col-last-used-cell .icon { font-size: 14px; color: var(--color-text-subtle); }
+.keys-table .col-never { color: var(--color-text-muted); font-style: italic; }
+
+/* Keys page header: title block left, primary action right */
+.keys-page-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.4rem; }
+.keys-page-header .page-header { margin-bottom: 0; }
+
+/* Auth banner: info strip with a docs link */
+.auth-banner { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem 1.5rem; flex-wrap: wrap; background: color-mix(in oklab, var(--color-info) 12%, var(--color-surface-raised)); border: 1px solid color-mix(in oklab, var(--color-info) 30%, var(--color-border)); border-radius: var(--radius-lg); padding: 0.75rem 1rem; margin-bottom: 1.4rem; }
+.auth-banner-text { display: inline-flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; color: var(--color-text); min-width: 0; }
+.auth-banner-text .icon { font-size: 18px; color: var(--color-info); flex-shrink: 0; }
+.auth-banner-text code { font-family: var(--font-family-mono); font-size: 0.8rem; background: var(--color-surface); padding: 0.1rem 0.4rem; border-radius: var(--radius-sm); }
+.auth-banner-link { display: inline-flex; align-items: center; gap: 0.3rem; font-size: 0.8rem; color: var(--color-success); text-decoration: none; white-space: nowrap; margin-left: auto; }
+.auth-banner-link:hover { text-decoration: underline; }
+.auth-banner-link .icon { font-size: 14px; }
+
+/* Quick-start code block with a copy button */
+.code-block { position: relative; margin-top: 0.75rem; }
+.code-block pre { background: var(--color-canvas); border: 1px solid var(--color-border); border-radius: var(--radius-md); padding: 0.85rem 2.75rem 0.85rem 1rem; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.code-block code { font-family: var(--font-family-mono); font-size: 0.8rem; color: var(--color-text); white-space: pre; line-height: 1.7; }
+.code-block-copy { position: absolute; top: 0.5rem; right: 0.5rem; width: 30px; height: 30px; border-radius: var(--radius-md); color: var(--color-text-muted); background: var(--color-surface-raised); }
+.code-block-copy:hover { color: var(--color-text); background: var(--color-surface-interactive); }
+.code-block-copy .icon { font-size: 16px; }
+.quick-start-hint { font-size: 0.813rem; color: var(--color-text-muted); margin-top: 0.25rem; }
 
 /* Links page: search-results bar + inline toolbar group */
 .search-results-bar { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }


### PR DESCRIPTION
Closes #20.

Redesigns the API keys admin page (`src/pages/keys.tsx`) so it onboards developers instead of only listing keys. A first-time visitor can copy a working `curl` request and find SDK install coordinates without leaving the page.

## What changed

**Header**
- "New key" action moved into the header row, top right; the separate toolbar and the standalone count line are gone.
- Title and button sentence-cased ("API keys", "New key").

**Auth banner**
- Replaces the plain docs note with an info banner: "Authenticate requests with a key in the `Authorization` header." `Authorization` renders as inline `<code>`; the "API documentation" link is right-aligned with an external-link icon.

**Quick start card**
- Copyable `curl` example that lists links with a Bearer key. The base URL is the **live request origin**, so the copied command runs as-is against the deployment. Copy button uses a new `copyCodeBlock` client helper.

**SDK card**
- Lists the three published SDKs (TypeScript `@oddbit/shrtnr`, Python `shrtnr`, Dart `shrtnr`) with registry links, via a shared `SdkList` component.

**Table**
- Key prefix renders masked (`sk_84cc••••••`) for a consistent secret-style display.
- "Last used" gains a clock icon; the italic "Never" empty state and the delete action are unchanged.

## Implementation notes

- **Shared component (no drift):** the SDK list lived inline in `settings.tsx`; it is extracted into `src/pages/sdk-list.tsx` and reused by both pages. Package coordinates stay in the existing `settings.sdk*` i18n strings, so they live in one place (first commit, a pure refactor).
- **i18n:** all new copy goes through `t()` under `keys.*` across `en`/`id`/`sv`; the now-unused `keys.count`/`keys.countPlural`/`keys.docsNote` strings are removed from all three locales. The compile-time `Translations = typeof en` type plus the existing locale-parity test enforce parity.
- **Styles:** new classes (`auth-banner`, `code-block`, `keys-page-header`, `col-key-mask`) extend the centralized stylesheet and reuse the existing `bento` / `integration-sdk-*` patterns. No inline styles.

## Testing

- New `src/__tests__/page/keys-page.test.ts` (written first, TDD) covering the header action, auth banner + inline code, quick-start curl against the live origin, the copy-helper wiring, SDK coordinates + registry links, and the masked prefix.
- Full suite: **1026 passing**. `tsc --noEmit` clean. OpenAPI spec hash unchanged (no API surface change), so the `sdk-spec-drift` gate stays green.

## Not verified

Automated coverage is structural (rendered HTML). I did not run a live visual pass, so a quick glance at the rendered page in the running app is worth a reviewer's eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
