### PR TITLE
Improve scope badge layout with flexbox container

### DIFF
--- a/src/pages/keys.tsx
+++ b/src/pages/keys.tsx
@@ -131,9 +131,11 @@ export const KeysPage: FC<Props> = ({ keys, t, lang, origin }) => {
                         <span class="col-key-mask">{k.key_prefix}{KEY_MASK}</span>
                       </td>
                       <td data-label={t("keys.colScope")}>
-                        {scopes.map((s) => (
-                          <span class={`scope-badge ${s}`}>{s} </span>
-                        ))}
+                        <span class="scope-badges">
+                          {scopes.map((s) => (
+                            <span class={`scope-badge ${s}`}>{s}</span>
+                          ))}
+                        </span>
                       </td>
                       <td data-label={t("keys.colCreated")} class="col-date">
                         {formatDate(k.created_at, lang)}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -755,6 +755,7 @@ select.form-input { appearance: none; -webkit-appearance: none; padding-right: 2
 .keys-table td { padding: 0.75rem 1rem; border-bottom: 1px solid var(--color-border); font-size: 0.875rem; vertical-align: middle; }
 .keys-table tr:last-child td { border-bottom: none; }
 .keys-table tr:hover td { background: var(--color-surface-interactive); }
+.scope-badges { display: inline-flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; }
 .scope-badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: var(--radius-md); font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.03em; }
 .scope-badge.create { background: var(--color-selection); color: var(--color-accent); border: 1px solid var(--color-accent); }
 .scope-badge.read { background: rgba(181,242,175,0.1); color: var(--color-success); border: 1px solid var(--color-success); }


### PR DESCRIPTION
Wrap scope badges in a flex container to enable proper layout and spacing of multiple badges in the keys table.

## Summary
Refactored the scope badges rendering in the keys table to use a dedicated container with flexbox styling, improving visual presentation and maintainability.

## Changes
- Added `.scope-badges` wrapper element around the scope badge map in `keys.tsx`
- Introduced `.scope-badges` CSS class with `display: inline-flex`, `flex-wrap: wrap`, and `gap: 0.5rem` to properly space and align badges
- Removed trailing space from individual badge text (changed `{s} ` to `{s}`)

## Implementation details
The new flex container allows badges to wrap naturally on smaller viewports while maintaining consistent spacing via the gap property. This follows the project's styling convention of using centralized style files rather than inline styles.

https://claude.ai/code/session_01AHF6Er118BqJPKsxqhW665