### PR TITLE
Code review fixes: ownership gaps, stored XSS, URL normalization, SDK parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Each SDK records the SHA-256 of the OpenAPI spec it was last regenerated against
 | Python | `sdk/python/pyproject.toml` | `[tool.shrtnr]` `spec_hash` |
 | Dart | `sdk/dart/pubspec.yaml` | leading comment `# x-spec-hash:` (top-level keys would draw a pana warning) |
 
-Spec changes (edits to `src/api/router.ts`, `src/api/schemas.ts`, or any resource sub-app affecting the generated doc) stale all three hashes. A root `package.json` version bump also drifts the hash because the spec embeds `info.version`. CI enforces via `.github/workflows/sdk-spec-drift.yml`.
+Spec changes (edits to `src/api/router.ts`, `src/api/schemas.ts`, or any resource sub-app affecting the generated doc) stale all three hashes. A root `package.json` version bump also drifts the hash because the spec embeds `info.version`. CI enforces via the `sdk-spec-drift` job in `.github/workflows/ci.yml`.
 
 Workflow on API change:
 

--- a/scripts/bump-sdk-version.sh
+++ b/scripts/bump-sdk-version.sh
@@ -170,8 +170,9 @@ echo "  1. edit $CHANGELOG and replace the TODO placeholder"
 echo "  2. git add $MANIFEST $CHANGELOG"
 echo "  3. git commit -m \"Release $SDK $NEW_VERSION: <short summary>\""
 if [ "$SDK" = "pub" ]; then
-  echo "  4. git tag ${TAG_PREFIX}${NEW_VERSION}"
-  echo "  5. git push origin main ${TAG_PREFIX}${NEW_VERSION}"
+  echo "  4. git tag ${TAG_PREFIX}${NEW_VERSION}   (create locally, do not push yet)"
+  echo "     pub.dev publishes on tag push, so push the tag only when you are"
+  echo "     ready to release: git push origin ${TAG_PREFIX}${NEW_VERSION}"
 else
   echo "  4. gh pr create  (or push to main — CI tags after publish)"
 fi

--- a/sdk/dart/README.md
+++ b/sdk/dart/README.md
@@ -50,7 +50,7 @@ closed by `client.close()`.
 | `get(id, {range?})` | Get a link with click count |
 | `list({owner?, range?})` | List all links |
 | `create({url, label?, slugLength?, expiresAt?, allowDuplicate?})` | Create a short link |
-| `update(id, {url?, label?, expiresAt?})` | Update URL, label, or expiry |
+| `update(link)` | Update URL, label, or expiry (pass a `Link` from `copyWith`) |
 | `disable(id)` | Stop redirecting |
 | `enable(id)` | Resume redirecting |
 | `delete(id)` | Permanently delete |
@@ -65,10 +65,10 @@ closed by `client.close()`.
 final link = await client.links.create(url: 'https://example.com', label: 'Landing page');
 
 // Get a 7-day click count
-final fresh = await client.links.get(link.id, range: '7d');
+final fresh = await client.links.get(link.id, range: TimelineRange.last7d);
 
 // Full analytics for the last 30 days
-final stats = await client.links.analytics(link.id, range: '30d');
+final stats = await client.links.analytics(link.id, range: TimelineRange.last30d);
 print('${stats.totalClicks} clicks, ${stats.numCountries} countries');
 ```
 
@@ -100,7 +100,7 @@ Groups of related links with combined analytics.
 | `get(id, {range?})` | Get a bundle with click summary |
 | `list({archived?, range?})` | List bundles |
 | `create({name, description?, icon?, accent?})` | Create a bundle |
-| `update(id, {name?, description?, icon?, accent?})` | Update metadata |
+| `update(bundle)` | Update metadata (pass a `Bundle` from `copyWith`) |
 | `delete(id)` | Permanently delete |
 | `archive(id)` | Hide from default listing |
 | `unarchive(id)` | Restore an archived bundle |
@@ -112,12 +112,12 @@ Groups of related links with combined analytics.
 
 ```dart
 // Create a bundle and add links to it
-final bundle = await client.bundles.create(name: 'Spring 2026', accent: 'green');
+final bundle = await client.bundles.create(name: 'Spring 2026', accent: BundleAccent.green);
 await client.bundles.addLink(bundle.id, linkA.id);
 await client.bundles.addLink(bundle.id, linkB.id);
 
 // Combined analytics for the last 7 days
-final stats = await client.bundles.analytics(bundle.id, range: '7d');
+final stats = await client.bundles.analytics(bundle.id, range: TimelineRange.last7d);
 print(stats.totalClicks);
 ```
 
@@ -130,8 +130,9 @@ Key types exported from `package:shrtnr/shrtnr.dart`:
 
 - `Link`, `Slug`, `Bundle`, `BundleWithSummary`, `BundleTopLink`
 - `ClickStats`, `TimelineData`, `TimelineBucket`, `TimelineSummary`, `NameCount`
-- `DateClickCount`, `SlugClickCount`
+- `DateCount`, `SlugCount`
 - `DeletedResult`, `AddedResult`, `RemovedResult`
+- Enums: `TimelineRange`, `BundleAccent`, `BreakdownDimension`, `BundleArchivedFilter`
 
 Timestamp fields (`createdAt`, `expiresAt`, `disabledAt`, `archivedAt`, `updatedAt`) are
 plain `int` Unix seconds, matching the wire format exactly.

--- a/sdk/dart/lib/src/errors.dart
+++ b/sdk/dart/lib/src/errors.dart
@@ -19,5 +19,5 @@ class ShrtnrError implements Exception {
   final String serverMessage;
 
   @override
-  String toString() => 'shrtnr API error (HTTP $status): $serverMessage';
+  String toString() => 'ShrtnrError(HTTP $status): $serverMessage';
 }

--- a/sdk/dart/lib/src/errors.dart
+++ b/sdk/dart/lib/src/errors.dart
@@ -19,5 +19,5 @@ class ShrtnrError implements Exception {
   final String serverMessage;
 
   @override
-  String toString() => 'ShrtnrError(HTTP $status): $serverMessage';
+  String toString() => 'shrtnr API error (HTTP $status): $serverMessage';
 }

--- a/sdk/dart/lib/src/models.dart
+++ b/sdk/dart/lib/src/models.dart
@@ -102,14 +102,17 @@ enum TimelineRange {
 /// uses [trueValue] and [activeOnly]. The wire value `"1"` is omitted because
 /// it is a semantic alias for `"true"`; use [trueValue] for both.
 enum BundleArchivedFilter {
-  /// Include archived bundles alongside active ones (wire: `"true"`). Also
-  /// covers the `"1"` alias from the spec; prefer this member for both.
+  /// Return only archived bundles (wire: `"true"`). Also covers the `"1"`
+  /// alias from the spec; prefer this member for both.
   trueValue,
 
-  /// Return only archived bundles (wire: `"only"`).
+  /// Return only archived bundles (wire: `"only"`). Despite the name, the
+  /// server's `"only"` value returns archived bundles only, the same result
+  /// as [trueValue]. The name is misleading and is kept for wire
+  /// compatibility; a rename awaits the next major version.
   activeOnly,
 
-  /// Return all bundles regardless of archived status (wire: `"all"`).
+  /// Include archived bundles alongside active ones (wire: `"all"`).
   all;
 
   static const _wireValues = {

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the SDK are documented in this file.
 
+## 1.1.1
+
+- `links.qr()` now takes `size` as an `int` instead of a `str`, matching the API schema (which validates an integer) and the TypeScript and Dart SDKs. Callers who passed an int already got the correct behavior; the annotation was the only thing out of step.
+
 ## 1.1.0 (2026-06-19)
 
 - Add `links.breakdown` and `bundles.breakdown` (sync and async) for paging through the countries, sources and domains analytics panels (offset/limit, returns items + total).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -65,7 +65,7 @@ with Shrtnr(base_url="...", api_key="sk_...") as client:
 | `get(id, *, range=None)` | Get a link with click count |
 | `list(*, owner=None, range=None)` | List all links |
 | `create(*, url, label=None, slug_length=None, expires_at=None, allow_duplicate=None)` | Create a short link |
-| `update(id, *, url=None, label=None, expires_at=None)` | Update URL, label, or expiry |
+| `update(id, *, url=None, label=UNSET, expires_at=UNSET)` | Update URL, label, or expiry. Omit a field to leave it unchanged; pass `None` to clear it |
 | `disable(id)` | Stop redirecting |
 | `enable(id)` | Resume redirecting |
 | `delete(id)` | Permanently delete |
@@ -115,7 +115,7 @@ Groups of related links with combined analytics.
 | `get(id, *, range=None)` | Get a bundle with click summary |
 | `list(*, archived=None, range=None)` | List bundles |
 | `create(*, name, description=None, icon=None, accent=None)` | Create a bundle |
-| `update(id, *, name=None, description=None, icon=None, accent=None)` | Update metadata |
+| `update(id, *, name=None, description=UNSET, icon=UNSET, accent=None)` | Update metadata. Omit a field to leave it unchanged; pass `None` to clear `description` or `icon` |
 | `delete(id)` | Permanently delete |
 | `archive(id)` | Hide from default listing |
 | `unarchive(id)` | Restore an archived bundle |

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shrtnr"
-version = "1.1.0"
+version = "1.1.1"
 description = "SDK for the shrtnr URL shortener API"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -77,6 +77,12 @@ include = [
 line-length = 100
 target-version = "py310"
 
+[tool.ruff.format]
+# ruff 0.16 formats Python blocks inside Markdown. README samples align their
+# trailing comments to match the Dart and TypeScript READMEs, so leave them
+# alone. `ruff check` still lints those blocks.
+exclude = ["*.md"]
+
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "UP", "B", "SIM", "RUF"]
 ignore = ["E501"]

--- a/sdk/python/src/shrtnr/resources/links.py
+++ b/sdk/python/src/shrtnr/resources/links.py
@@ -171,13 +171,13 @@ class Links:
         url = self._url(f"/_/api/links/{id}/timeline", {"range": range})
         return TimelineData.from_dict(self._request("GET", url, headers=self._headers()))
 
-    def qr(self, id: int, *, slug: str | None = None, size: str | None = None) -> str:
+    def qr(self, id: int, *, slug: str | None = None, size: int | None = None) -> str:
         """Get the QR code SVG for a link. Returns the SVG string."""
         query: dict[str, str | None] = {}
         if slug is not None:
             query["slug"] = slug
         if size is not None:
-            query["size"] = size
+            query["size"] = str(size)
         url = self._url(f"/_/api/links/{id}/qr", query or None)
         return self._request_text("GET", url, headers=self._headers())
 
@@ -327,13 +327,13 @@ class AsyncLinks:
         url = self._url(f"/_/api/links/{id}/timeline", {"range": range})
         return TimelineData.from_dict(await self._request("GET", url, headers=self._headers()))
 
-    async def qr(self, id: int, *, slug: str | None = None, size: str | None = None) -> str:
+    async def qr(self, id: int, *, slug: str | None = None, size: int | None = None) -> str:
         """Get the QR code SVG for a link. Returns the SVG string."""
         query: dict[str, str | None] = {}
         if slug is not None:
             query["slug"] = slug
         if size is not None:
-            query["size"] = size
+            query["size"] = str(size)
         url = self._url(f"/_/api/links/{id}/qr", query or None)
         return await self._request_text("GET", url, headers=self._headers())
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -341,7 +341,7 @@ def test_links_qr_with_slug_and_size(client: Shrtnr) -> None:
     route = respx.get(url__regex=rf"^{BASE_URL}/_/api/links/5/qr\?").mock(
         return_value=httpx.Response(200, text="<svg/>"),
     )
-    client.links.qr(5, slug="promo", size="200")
+    client.links.qr(5, slug="promo", size=200)
     url = str(route.calls[0].request.url)
     assert "slug=promo" in url
     assert "size=200" in url

--- a/src/__tests__/handler/mcp.test.ts
+++ b/src/__tests__/handler/mcp.test.ts
@@ -235,7 +235,7 @@ describe("MCP tool behavior (service layer)", () => {
 
     const result = await updateLink(env as never, created.data.id, {
       url: "https://example.com/updated",
-    });
+    }, "anonymous");
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.data.url).toBe("https://example.com/updated");

--- a/src/__tests__/page/keys-page.test.ts
+++ b/src/__tests__/page/keys-page.test.ts
@@ -113,6 +113,13 @@ describe("Keys page table", () => {
   it("keeps the delete action for each key", async () => {
     await seedApiKey();
     const html = await fetchKeysHtml();
-    expect(html).toContain("deleteKey(");
+    // The delete action rides on data-* attributes read by a delegated handler
+    // rather than an inline onclick, so a key title cannot break out into
+    // executable script. The title is carried verbatim on data-delete-key-title.
+    expect(html).toMatch(/data-delete-key="\d+"/);
+    expect(html).toContain('data-delete-key-title=');
+    // The vulnerable inline onclick handler must be gone from the markup. The
+    // client script still defines deleteKey(), so target the attribute form.
+    expect(html).not.toContain('onclick="deleteKey(');
   });
 });

--- a/src/__tests__/page/link-detail-page.test.ts
+++ b/src/__tests__/page/link-detail-page.test.ts
@@ -44,6 +44,27 @@ describe("Link detail page server render", () => {
     expect(slugCount![1].trim()).toBe("2");
   });
 
+  it("renders the duplicate action without interpolating the URL into an inline handler", async () => {
+    // A URL with a literal single quote must not break out of the duplicate
+    // button. The URL rides on a data-* attribute (HTML-escaped by JSX) and a
+    // delegated handler reads it, so no inline onclick carries the raw URL.
+    const link = await LinkRepository.create(env.DB, {
+      url: "https://example.com/'-alert(document.cookie)-'",
+      slug: "abc",
+    });
+
+    const res = await SELF.fetch(req(`/_/admin/links/${link.id}`));
+    const html = await res.text();
+
+    expect(html).toContain("data-duplicate-url=");
+    // The client script still defines showDuplicateModal(); the fix is that no
+    // inline onclick attribute carries the raw URL.
+    expect(html).not.toContain('onclick="showDuplicateModal(');
+    // The quote survives only in escaped form, never as a raw breakout.
+    expect(html).not.toContain("'-alert(document.cookie)-'");
+    expect(html).toContain("&#39;-alert(document.cookie)-&#39;");
+  });
+
   it("hero total_clicks honors a user's default_range setting", async () => {
     const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
     const slug = link.slugs[0].slug;

--- a/src/__tests__/service/link-service.test.ts
+++ b/src/__tests__/service/link-service.test.ts
@@ -120,7 +120,7 @@ describe("link-management service", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    const result = await updateLink(env as any, created.data.id, { url: "javascript:alert(1)" });
+    const result = await updateLink(env as any, created.data.id, { url: "javascript:alert(1)" }, "anonymous");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(400);
@@ -135,7 +135,7 @@ describe("link-management service", () => {
     const fetched = await getLink(env as any, created.data.id);
     expect(fetched.ok).toBe(true);
 
-    const updated = await updateLink(env as any, created.data.id, { label: "Updated" });
+    const updated = await updateLink(env as any, created.data.id, { label: "Updated" }, "anonymous");
     expect(updated.ok).toBe(true);
     if (updated.ok) {
       expect(updated.data.label).toBe("Updated");
@@ -307,7 +307,7 @@ describe("URL normalization in updateLink", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    const updated = await updateLink(env as any, created.data.id, { url: "https://example.com/new-path/" });
+    const updated = await updateLink(env as any, created.data.id, { url: "https://example.com/new-path/" }, "anonymous");
     expect(updated.ok).toBe(true);
     if (updated.ok) {
       expect(updated.data.url).toBe("https://example.com/new-path");
@@ -319,7 +319,7 @@ describe("URL normalization in updateLink", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    const updated = await updateLink(env as any, created.data.id, { url: "https://example.com/page?" });
+    const updated = await updateLink(env as any, created.data.id, { url: "https://example.com/page?" }, "anonymous");
     expect(updated.ok).toBe(true);
     if (updated.ok) {
       expect(updated.data.url).toBe("https://example.com/page");
@@ -331,7 +331,7 @@ describe("URL normalization in updateLink", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    const updated = await updateLink(env as any, created.data.id, { label: null });
+    const updated = await updateLink(env as any, created.data.id, { label: null }, "anonymous");
     expect(updated.ok).toBe(true);
     if (updated.ok) {
       expect(updated.data.label).toBeNull();
@@ -389,7 +389,7 @@ describe("field type validation in updateLink", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    const updated = await updateLink(env as any, created.data.id, { expires_at: "never" as any });
+    const updated = await updateLink(env as any, created.data.id, { expires_at: "never" as any }, "anonymous");
     expect(updated.ok).toBe(false);
     if (!updated.ok) expect(updated.status).toBe(400);
   });
@@ -399,7 +399,7 @@ describe("field type validation in updateLink", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    const updated = await updateLink(env as any, created.data.id, { label: 42 as any });
+    const updated = await updateLink(env as any, created.data.id, { label: 42 as any }, "anonymous");
     expect(updated.ok).toBe(false);
     if (!updated.ok) expect(updated.status).toBe(400);
   });
@@ -409,7 +409,7 @@ describe("field type validation in updateLink", () => {
     expect(created.ok).toBe(true);
     if (!created.ok) return;
 
-    const updated = await updateLink(env as any, created.data.id, { expires_at: null });
+    const updated = await updateLink(env as any, created.data.id, { expires_at: null }, "anonymous");
     expect(updated.ok).toBe(true);
     if (updated.ok) expect(updated.data.expires_at).toBeNull();
   });

--- a/src/__tests__/service/ownership.test.ts
+++ b/src/__tests__/service/ownership.test.ts
@@ -12,6 +12,8 @@ import {
   enableSlug,
   removeSlug,
   addCustomSlugToLink,
+  updateLink,
+  setSlugPrimary,
   searchLinks,
   listLinksByOwner,
 } from "../../services/link-management";
@@ -84,6 +86,48 @@ describe("Link ownership: delete", () => {
   it("non-owner cannot delete another user's link", async () => {
     const link = await createOwnedLink();
     const result = await deleteLink(env as any, link.id, OTHER);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+    }
+  });
+});
+
+describe("Link ownership: update", () => {
+  it("owner can update their link", async () => {
+    const link = await createOwnedLink();
+    const result = await updateLink(env as any, link.id, { url: "https://example.com/moved" }, OWNER);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.url).toBe("https://example.com/moved");
+    }
+  });
+
+  it("non-owner cannot update another user's link", async () => {
+    const link = await createOwnedLink();
+    const result = await updateLink(env as any, link.id, { url: "https://evil.example" }, OTHER);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+    }
+    // The destination must be untouched after a rejected update.
+    const after = await LinkRepository.getById(env.DB, link.id);
+    expect(after!.url).toBe("https://example.com");
+  });
+});
+
+describe("Slug ownership: set primary", () => {
+  it("link owner can change the primary slug", async () => {
+    const link = await createOwnedLink();
+    await addCustomSlugToLink(env as any, link.id, { slug: "primary-pick" });
+    const result = await setSlugPrimary(env as any, link.id, "primary-pick", OWNER);
+    expect(result.ok).toBe(true);
+  });
+
+  it("non-owner cannot change the primary slug on another user's link", async () => {
+    const link = await createOwnedLink();
+    await addCustomSlugToLink(env as any, link.id, { slug: "primary-pick" });
+    const result = await setSlugPrimary(env as any, link.id, "primary-pick", OTHER);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.status).toBe(403);

--- a/src/__tests__/unit/normalize-url.test.ts
+++ b/src/__tests__/unit/normalize-url.test.ts
@@ -63,4 +63,22 @@ describe("normalizeUrl", () => {
       "https://example.com#section",
     );
   });
+
+  it("preserves a trailing slash inside a query value", () => {
+    expect(normalizeUrl("https://example.com/search?q=cats/")).toBe(
+      "https://example.com/search?q=cats/",
+    );
+  });
+
+  it("preserves a trailing slash inside an embedded URL parameter", () => {
+    expect(normalizeUrl("https://example.com/a?next=https://b.com/")).toBe(
+      "https://example.com/a?next=https://b.com/",
+    );
+  });
+
+  it("preserves a hash-router route that ends in a slash", () => {
+    expect(normalizeUrl("https://example.com/#/spa/route/")).toBe(
+      "https://example.com/#/spa/route/",
+    );
+  });
 });

--- a/src/api/links.ts
+++ b/src/api/links.ts
@@ -165,7 +165,7 @@ const updateLinkRoute = createRoute({
 linksApp.openapi(updateLinkRoute, async (c) => {
   const { id } = c.req.valid("param") as { id: number };
   const body = c.req.valid("json") as { url?: string; label?: string | null; expires_at?: number | null };
-  return fromServiceResult(await updateLink(c.env, id, body)) as never;
+  return fromServiceResult(await updateLink(c.env, id, body, c.var.auth.identity)) as never;
 }, paramHook);
 
 // ---- POST /:id/disable ----
@@ -510,7 +510,7 @@ export async function handleCreateLink(request: Request, env: Env, createdVia?: 
   return fromServiceResult(result);
 }
 
-export async function handleUpdateLink(request: Request, env: Env, id: number): Promise<Response> {
+export async function handleUpdateLink(request: Request, env: Env, id: number, identity: string): Promise<Response> {
   let body: { url?: string; label?: string | null; expires_at?: number | null };
 
   try {
@@ -519,7 +519,7 @@ export async function handleUpdateLink(request: Request, env: Env, id: number): 
     return json({ error: "Invalid JSON body" }, 400);
   }
 
-  return fromServiceResult(await updateLink(env, id, body));
+  return fromServiceResult(await updateLink(env, id, body, identity));
 }
 
 export async function handleDisableLink(env: Env, id: number, identity: string): Promise<Response> {

--- a/src/api/qr.ts
+++ b/src/api/qr.ts
@@ -43,7 +43,11 @@ export async function handleLinkQr(request: Request, env: Env, linkId: number): 
   return new Response(svg, {
     headers: {
       "Content-Type": "image/svg+xml",
-      "Cache-Control": "public, max-age=86400",
+      // private, not public: this endpoint sits behind a bearer token, and
+      // public would let a shared cache store the authenticated response and
+      // serve the link-id to slug mapping to unauthenticated clients. private
+      // keeps the same browser caching without the shared-cache waiver.
+      "Cache-Control": "private, max-age=86400",
     },
   });
 }

--- a/src/api/slugs.ts
+++ b/src/api/slugs.ts
@@ -37,6 +37,7 @@ export async function handleSetPrimarySlug(
   request: Request,
   env: Env,
   linkId: number,
+  identity: string,
 ): Promise<Response> {
   let body: { slug?: string };
   try {
@@ -45,7 +46,7 @@ export async function handleSetPrimarySlug(
     return json({ error: "Invalid JSON body" }, 400);
   }
   if (!body.slug) return json({ error: "slug is required" }, 400);
-  return fromServiceResult(await setSlugPrimary(env, linkId, body.slug));
+  return fromServiceResult(await setSlugPrimary(env, linkId, body.slug, identity));
 }
 
 export async function handleDisableSlug(

--- a/src/client.ts
+++ b/src/client.ts
@@ -450,9 +450,9 @@ function doSetPrimary(linkId, slug) {
 }
 
 // ---- Duplicate link modal ----
-// Holds the URL to duplicate while the confirm modal is open. Keeping it in a
-// closure variable avoids interpolating a user-controlled URL into an inline
-// onclick JS-string, which esc() cannot make safe (it does not escape ').
+// Holds the URL to duplicate while the confirm modal is open. Parking it in a
+// script-scope variable avoids interpolating a user-controlled URL into an
+// inline onclick JS-string, which esc() cannot make safe (it does not escape ').
 var pendingDuplicateUrl = null;
 function showDuplicateModal(linkId, url) {
   pendingDuplicateUrl = url;

--- a/src/client.ts
+++ b/src/client.ts
@@ -450,17 +450,23 @@ function doSetPrimary(linkId, slug) {
 }
 
 // ---- Duplicate link modal ----
+// Holds the URL to duplicate while the confirm modal is open. Keeping it in a
+// closure variable avoids interpolating a user-controlled URL into an inline
+// onclick JS-string, which esc() cannot make safe (it does not escape ').
+var pendingDuplicateUrl = null;
 function showDuplicateModal(linkId, url) {
+  pendingDuplicateUrl = url;
   document.getElementById('detail-menu').style.display = 'none';
   openModal(
     '<div class="modal-title">' + esc(t('linkDetail.duplicateTitle')) + '</div>' +
     '<p style="font-size:0.875rem;color:var(--color-text-muted);margin-bottom:0.75rem">' + esc(t('linkDetail.duplicateBody')) + '</p>' +
     '<p style="font-size:0.8rem;color:var(--color-text-muted);margin-bottom:1.5rem;opacity:0.7">' + esc(t('linkDetail.duplicateHelper')) + '</p>' +
-    '<div class="modal-actions"><button class="btn btn-ghost" onclick="closeModal()">' + esc(t('client.cancel')) + '</button><button class="btn btn-primary" onclick="doDuplicate(\\'' + esc(url).replace(/'/g, "\\\\'") + '\\')">' + esc(t('linkDetail.duplicate')) + '</button></div>'
+    '<div class="modal-actions"><button class="btn btn-ghost" onclick="closeModal()">' + esc(t('client.cancel')) + '</button><button class="btn btn-primary" onclick="doDuplicate()">' + esc(t('linkDetail.duplicate')) + '</button></div>'
   );
 }
-function doDuplicate(url) {
-  createDuplicate(url);
+function doDuplicate() {
+  if (pendingDuplicateUrl != null) createDuplicate(pendingDuplicateUrl);
+  pendingDuplicateUrl = null;
   closeModal();
 }
 
@@ -1589,6 +1595,28 @@ document.addEventListener('click', function(ev) {
   ev.preventDefault();
   ev.stopPropagation();
   copyUrl(slug);
+});
+
+// Open the duplicate-link modal from a data-* button. The link URL rides on a
+// data attribute rather than an inline onclick argument so a URL containing a
+// quote cannot break out into executable script.
+document.addEventListener('click', function(ev) {
+  var el = ev.target && ev.target.closest ? ev.target.closest('[data-duplicate-url]') : null;
+  if (!el) return;
+  ev.preventDefault();
+  var linkId = parseInt(el.getAttribute('data-duplicate-link'), 10);
+  showDuplicateModal(linkId, el.getAttribute('data-duplicate-url'));
+});
+
+// Delete an API key from a data-* button. The key title rides on a data
+// attribute so a title containing a quote or backslash cannot break out of an
+// inline onclick argument.
+document.addEventListener('click', function(ev) {
+  var el = ev.target && ev.target.closest ? ev.target.closest('[data-delete-key]') : null;
+  if (!el) return;
+  ev.preventDefault();
+  var keyId = parseInt(el.getAttribute('data-delete-key'), 10);
+  deleteKey(keyId, el.getAttribute('data-delete-key-title') || '');
 });
 `;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -389,7 +389,7 @@ app.get("/_/admin/api/links/:id", (c) => {
 app.put("/_/admin/api/links/:id", (c) => {
   const id = parseInt(c.req.param("id"), 10);
   if (isNaN(id)) return c.json({ error: "Not Found" }, 404);
-  return handleUpdateLink(c.req.raw, c.env, id);
+  return handleUpdateLink(c.req.raw, c.env, id, c.var.identity);
 });
 app.get("/_/admin/api/links/:id/analytics", (c) => {
   const id = parseInt(c.req.param("id"), 10);
@@ -434,7 +434,7 @@ app.post("/_/admin/api/links/:id/slugs", (c) => {
 app.put("/_/admin/api/links/:id/slugs/primary", (c) => {
   const id = parseInt(c.req.param("id"), 10);
   if (isNaN(id)) return c.json({ error: "Not Found" }, 404);
-  return handleSetPrimarySlug(c.req.raw, c.env, id);
+  return handleSetPrimarySlug(c.req.raw, c.env, id, c.var.identity);
 });
 app.post("/_/admin/api/links/:id/slugs/:slug/disable", (c) => {
   const id = parseInt(c.req.param("id"), 10);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -268,7 +268,7 @@ export class ShrtnrMCP extends McpAgent<Env, Record<string, never>, Props> {
         annotations: { title: "Update link", ...WRITE_IDEMPOTENT },
       },
       async ({ link_id, ...opts }) => {
-        const result = await updateLink(this.env, link_id, opts);
+        const result = await updateLink(this.env, link_id, opts, this.identity);
         if (!result.ok) return fail(result.error);
         return ok(result.data);
       },

--- a/src/normalize-url.ts
+++ b/src/normalize-url.ts
@@ -3,8 +3,24 @@
 
 /**
  * Strips trailing characters that serve no purpose from a URL:
- * trailing `/`, `#` (without an anchor), and `?` (without parameters).
+ * trailing `/`, an empty `#` (no anchor), and an empty `?` (no parameters).
+ *
+ * The redundant characters are only stripped when they carry no content: a `/`,
+ * `?`, or `#` that is part of a query value or fragment is preserved. So
+ * `https://example.com/search?q=cats/` keeps its trailing slash, and
+ * `https://example.com/#/spa/route/` keeps its hash-router path intact.
  */
 export function normalizeUrl(url: string): string {
-  return url.replace(/[/?#]+$/, "");
+  let result = url;
+  // Drop an empty trailing fragment ("...#") then an empty trailing query
+  // ("...?"). Order matters: "path/?#" collapses to "path/" before the slash
+  // strip below can run.
+  if (result.endsWith("#")) result = result.slice(0, -1);
+  if (result.endsWith("?")) result = result.slice(0, -1);
+  // Trailing path slashes are redundant only when no query or fragment
+  // follows; a slash inside a query value or fragment is meaningful.
+  if (!result.includes("?") && !result.includes("#")) {
+    result = result.replace(/\/+$/, "");
+  }
+  return result;
 }

--- a/src/pages/keys.tsx
+++ b/src/pages/keys.tsx
@@ -3,7 +3,6 @@
 
 import type { FC } from "hono/jsx";
 import type { TranslateFn } from "../i18n";
-import { escHtml } from "../escape";
 import { SdkList } from "./sdk-list";
 
 // Bullets that stand in for the redacted tail of a key prefix, e.g. sk_84cc••••••.
@@ -153,7 +152,8 @@ export const KeysPage: FC<Props> = ({ keys, t, lang, origin }) => {
                       <td>
                         <button
                           class="btn btn-danger btn-sm"
-                          onclick={`deleteKey(${k.id},'${escHtml(k.title).replace(/'/g, "\\'")}')`}
+                          data-delete-key={k.id}
+                          data-delete-key-title={k.title}
                         >
                           <span class="icon icon-sm">delete</span>
                         </button>

--- a/src/pages/link-detail.tsx
+++ b/src/pages/link-detail.tsx
@@ -131,7 +131,7 @@ export const LinkDetailPage: FC<Props> = ({ link, analytics, bundles = [], t, la
                 <span class="icon">star</span> {t("linkDetail.changePrimary")}
               </button>
             )}
-            <button class="detail-menu-item" onclick={`showDuplicateModal(${link.id}, '${escHtml(link.url)}')`}>
+            <button class="detail-menu-item" data-duplicate-link={link.id} data-duplicate-url={link.url}>
               <span class="icon">content_copy</span> {t("linkDetail.duplicate")}
             </button>
             {isOwner && (

--- a/src/services/link-management.ts
+++ b/src/services/link-management.ts
@@ -147,7 +147,12 @@ export async function updateLink(
   env: Env,
   id: number,
   body: { url?: string; label?: string | null; expires_at?: number | null },
+  identity: string,
 ): Promise<ServiceResult<LinkWithSlugs>> {
+  const existing = await LinkRepository.getById(env.DB, id);
+  if (!existing) return fail(404, "Link not found");
+  if (existing.created_by !== identity) return fail(403, "Only the link owner can update this link");
+
   if (body.url !== undefined) {
     try {
       const parsed = new URL(body.url);
@@ -290,9 +295,11 @@ export async function setSlugPrimary(
   env: Env,
   linkId: number,
   slug: string,
+  identity: string,
 ): Promise<ServiceResult<LinkWithSlugs>> {
   const link = await LinkRepository.getById(env.DB, linkId);
   if (!link) return fail(404, "Link not found");
+  if (link.created_by !== identity) return fail(403, "Only the link owner can change the primary slug");
 
   const slugObj = link.slugs.find((s) => s.slug === slug);
   if (!slugObj) return fail(404, "Slug not found on this link");


### PR DESCRIPTION
A code-review pass surfaced two security bugs, a redirect-correctness bug, and several SDK parity/doc drifts. Each fix is a focused commit with tests where there is runtime surface to cover. The full Worker suite passes (1050 tests, 8 new), `tsc --noEmit` is clean, and the OpenAPI spec hash is unchanged so the `sdk-spec-drift` gate stays green.

## Security

**Missing ownership checks on link update and set-primary-slug** (`src/services/link-management.ts`)
`updateLink` and `setSlugPrimary` were the only link/slug mutations that took no caller identity, while `disableLink`/`enableLink`/`deleteLink`/`removeSlug`/`disableSlug`/`enableSlug` all return 403 when `created_by` does not match. Any create-scope API key or MCP session could repoint another owner's link to an arbitrary URL. Because link disable is implemented as `expires_at = now`, the open update path also let a non-owner disable or re-enable a link, bypassing the owner-only guard the tests explicitly pin. Added an `identity` argument to both service functions with a 403 on mismatch, threaded through the REST handlers, the admin routes, and the MCP `update_link` tool. New ownership tests cover the non-owner 403 for both operations.

**Stored XSS in the duplicate-link and delete-key buttons** (`src/pages/link-detail.tsx`, `src/pages/keys.tsx`, `src/client.ts`)
Both buttons interpolated user-controlled text (a link URL, an API-key title) into a single-quoted JS string inside an inline `onclick`. `escHtml()` deliberately does not escape the single quote (its own doc warns against exactly this), and the hand-rolled backslash escaping on the key title was defeated by a literal backslash. A link whose URL, or a key whose title, contained a quote could break out and run script in the admin origin. Moved both values onto `data-*` attributes read by delegated click handlers (matching the existing `data-copy-slug` pattern) and refactored `showDuplicateModal` so the confirm button no longer re-interpolates the URL. Regression tests cover a quote-bearing URL and the `data-*` delete action.

**QR endpoint served with `public` Cache-Control** (`src/api/qr.ts`)
The QR route sits behind a read-scoped bearer token, so `public` let a shared cache store the authenticated response and serve the link-id to slug mapping to unauthenticated clients. Changed to `private, max-age=86400`, same browser caching without the shared-cache waiver.

## Correctness

**`normalizeUrl` corrupted query and fragment content** (`src/normalize-url.ts`)
The regex `/[/?#]+$/` stripped any trailing `/`, `?`, or `#` unconditionally, so a slash inside a query value or a hash-router fragment was silently removed. `createLink`/`updateLink` store the normalized string and serve it as the 301 `Location`, so a link to `https://example.com/search?q=cats/` redirected to `.../search?q=cats`, and a hash-router target lost its trailing route. Now only strips genuinely redundant characters: an empty trailing fragment, an empty trailing query, and trailing path slashes when no query or fragment follows. Regression tests added for the query-value, embedded-URL, and hash-router cases.

## SDK parity and docs

- **Python `links.qr(size)`** typed as `str`; the API schema validates an integer and the TS SDK converted it to a number in 1.0.2 (Dart already takes an int). Retyped to `int` with internal stringify on both sync and async resources; bumped the Python SDK to 1.1.1 with a changelog entry.
- **Dart README** documented an `update(id, {...})` signature dropped in 2.0.0, passed string literals where `TimelineRange`/`BundleAccent` enums are required (examples did not compile), and named `DateClickCount`/`SlugClickCount` types that do not exist. Corrected to `update(link)`/`update(bundle)`, enum arguments, and the real `DateCount`/`SlugCount` plus the exported enum types.
- **Dart `BundleArchivedFilter`** doc comments inverted the server semantics (`true`/`1`/`only` all mean archived-only; `all` means include-archived). Corrected the comments and flagged `activeOnly` as a misnomer kept for wire compatibility (a rename is breaking and left for the next major).
- **Dart `ShrtnrError.toString()`** now uses the same `shrtnr API error (HTTP n)` prefix as the TS/Python SDKs it claims to mirror.
- **Python README** `update()` rows now show the `UNSET` sentinel defaults and the clear-vs-unchanged semantics, so passing `None` no longer reads as a no-op.
- **CLAUDE.md** pointed at a non-existent `sdk-spec-drift.yml`; the gate is the `sdk-spec-drift` job in `ci.yml`.
- **`bump-sdk-version.sh`** pub guidance no longer tells the user to push the tag immediately, matching the documented create-locally release rule.

## Notes / not addressed

A few findings were left out as they need a schema migration or a breaking change, better handled deliberately:

- **Disable/enable erases a future `expires_at`.** Link disable overwrites `expires_at` with `now` and enable sets it to `NULL`, so a disable/enable round-trip on a link with a real future expiry loses that expiry. Fixing it properly needs a separate `disabled_at` column (migration), so it is out of scope here.
- **Monthly sparkline bucketing** walks back in fixed 30-day steps while the SQL groups by calendar month, which can double-count a month near month-ends on the `1y`/`all` ranges. Worth a dedicated fix with its own tests.
- **`BundleArchivedFilter.activeOnly` rename** is a breaking SDK change; documented for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hq6S5qDhdv6adtSY3JFLSp)_