### PR TITLE
Weekly defect review: case-insensitive QR slugs, concurrent-delete races, SDK JSON-parse bug

### DIFF
--- a/sdk/dart/lib/src/base_client.dart
+++ b/sdk/dart/lib/src/base_client.dart
@@ -72,7 +72,11 @@ class ShrtnrBaseClient {
 
     if (response.statusCode >= 200 && response.statusCode < 300) {
       if (response.statusCode == 204 || response.body.isEmpty) return null;
-      return jsonDecode(response.body);
+      try {
+        return jsonDecode(response.body);
+      } catch (e) {
+        throw ShrtnrError(response.statusCode, 'Invalid JSON response: $e');
+      }
     }
 
     String serverMessage = 'HTTP ${response.statusCode}';

--- a/sdk/dart/test/client_test.dart
+++ b/sdk/dart/test/client_test.dart
@@ -227,6 +227,22 @@ void main() {
         expect(e.serverMessage, contains('connection refused'));
       }
     });
+
+    test(
+        'wraps a non-JSON 2xx body in ShrtnrError instead of throwing a raw FormatException',
+        () async {
+      final m = _mock(
+        status: 200,
+        body: '<html>Bad Gateway</html>',
+        contentType: 'text/html',
+      );
+      try {
+        await m.client.links.list();
+        fail('expected ShrtnrError');
+      } on ShrtnrError catch (e) {
+        expect(e.status, 200);
+      }
+    });
   });
 
   // ---- 3. links.get ----

--- a/sdk/typescript/src/internal/http.ts
+++ b/sdk/typescript/src/internal/http.ts
@@ -59,7 +59,13 @@ export class HttpClient {
 
     if (res.status === 204) return undefined as T;
 
-    const json: unknown = await res.json();
+    let json: unknown;
+    try {
+      json = await res.json();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new ShrtnrError(res.status, `Invalid JSON response: ${msg}`);
+    }
     return keysToCamel(json) as T;
   }
 

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -109,6 +109,17 @@ describe("Error handling", () => {
       expect((e as ShrtnrError).status).toBe(0);
     }
   });
+
+  it("wraps a non-JSON 2xx body in ShrtnrError instead of throwing a raw SyntaxError", async () => {
+    mockFetch(200, "<html>Bad Gateway</html>", "text/html");
+    try {
+      await client().links.list();
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ShrtnrError);
+      expect((e as ShrtnrError).status).toBe(200);
+    }
+  });
 });
 
 // ============================================================

--- a/src/__tests__/handler/api-links.test.ts
+++ b/src/__tests__/handler/api-links.test.ts
@@ -1287,4 +1287,23 @@ describe("GET /_/api/links/:id/qr size validation", () => {
     expect(explicitPrimary.status).toBe(200);
     expect(await noSlug.text()).toBe(await explicitPrimary.text());
   });
+
+  it("matches an explicit slug regardless of case, since stored slugs are always lowercase", async () => {
+    const createRes = await SELF.fetch(
+      authed("/_/admin/api/links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://example.com/qr-case" }),
+      })
+    );
+    expect(createRes.status).toBe(201);
+    const created = await createRes.json() as { id: number; slugs: { slug: string }[] };
+    const slug = created.slugs[0].slug;
+
+    const lower = await SELF.fetch(authed(`/_/admin/api/links/${created.id}/qr?slug=${slug}`));
+    const upper = await SELF.fetch(authed(`/_/admin/api/links/${created.id}/qr?slug=${slug.toUpperCase()}`));
+    expect(lower.status).toBe(200);
+    expect(upper.status).toBe(200);
+    expect(await upper.text()).toBe(await lower.text());
+  });
 });

--- a/src/__tests__/handler/mcp.test.ts
+++ b/src/__tests__/handler/mcp.test.ts
@@ -527,6 +527,40 @@ describe("MCP get_link_qr", () => {
     // (api/qr.ts), so redirect.ts records the scan with link_mode = "qr".
     expect(text).toContain(`https://shrtnr.test/${slug}?utm_medium=qr`);
   });
+
+  it("matches an explicit slug argument regardless of case, since stored slugs are always lowercase", async () => {
+    const created = await createLink(env as any, { url: "https://example.com/qr-case" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const slug = created.data.slugs[0].slug;
+
+    const sessionId = await initSession();
+    const res = await SELF.fetch(
+      new Request("https://shrtnr.test/_/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          "mcp-session-id": sessionId,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 5,
+          method: "tools/call",
+          params: {
+            name: "get_link_qr",
+            arguments: { link_id: created.data.id, slug: slug.toUpperCase(), base_url: "https://shrtnr.test" },
+          },
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const message = await readFirstSseMessage(res);
+    const result = message!.result as { isError?: boolean; content?: { type: string; text?: string }[] } | undefined;
+    expect(result?.isError).toBeFalsy();
+    const text = result?.content?.find((c) => c.type === "text")?.text ?? "";
+    expect(text).toContain(`https://shrtnr.test/${slug}?utm_medium=qr`);
+  });
 });
 
 describe("MCP error surface", () => {

--- a/src/__tests__/service/bundle-service.test.ts
+++ b/src/__tests__/service/bundle-service.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { env } from "cloudflare:test";
 import { applyMigrations, resetData } from "../setup";
-import { BundleRepository, LinkRepository } from "../../db";
+import { BundleRepository, ClickRepository, LinkRepository } from "../../db";
 import * as svc from "../../services/bundle-management";
 import type { Env } from "../../types";
 
@@ -317,6 +317,18 @@ describe("bundle concurrent-delete: null return propagates as 404", () => {
 
     const spy = vi.spyOn(BundleRepository, "unarchive").mockResolvedValueOnce(null);
     const res = await svc.unarchiveBundle(e, b.id, "a@b").finally(() => spy.mockRestore());
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.status).toBe(404);
+  });
+
+  it("getBundleAnalytics returns 404 when getBundleStats returns null (concurrent deletion)", async () => {
+    const b = await BundleRepository.create(env.DB, { name: "Raced", createdBy: "a@b" });
+
+    // getBundleAnalytics's own getById check passes, but getBundleStats does
+    // an independent getById internally and can see the bundle gone by then.
+    const spy = vi.spyOn(ClickRepository, "getBundleStats").mockResolvedValueOnce(null);
+    const res = await svc.getBundleAnalytics(e, b.id, "30d", "a@b").finally(() => spy.mockRestore());
 
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.status).toBe(404);

--- a/src/__tests__/service/link-service.test.ts
+++ b/src/__tests__/service/link-service.test.ts
@@ -6,9 +6,10 @@ import {
   createLink,
   getLink,
   getLinkBySlug,
+  setSlugPrimary,
   updateLink,
 } from "../../services/link-management";
-import { SettingRepository, SlugRepository } from "../../db";
+import { LinkRepository, SettingRepository, SlugRepository } from "../../db";
 
 beforeAll(applyMigrations);
 beforeEach(resetData);
@@ -435,6 +436,28 @@ describe("custom slug uniqueness under race conditions", () => {
         expect(result.status).toBe(409);
         expect(result.error).toBe("Slug already exists");
       }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("setSlugPrimary concurrent-delete: null return propagates as 404", () => {
+  it("returns 404 when the link is deleted between the membership check and the final read", async () => {
+    const created = await createLink(env as any, { url: "https://example.com/raced" });
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const slug = created.data.slugs[0].slug;
+
+    // Simulate a concurrent delete landing after setSlugPrimary's initial
+    // membership check but before its final getById re-read.
+    const spy = vi.spyOn(LinkRepository, "getById")
+      .mockResolvedValueOnce(created.data)
+      .mockResolvedValueOnce(null);
+    try {
+      const result = await setSlugPrimary(env as any, created.data.id, slug);
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.status).toBe(404);
     } finally {
       spy.mockRestore();
     }

--- a/src/api/qr.ts
+++ b/src/api/qr.ts
@@ -30,7 +30,7 @@ export async function handleLinkQr(request: Request, env: Env, linkId: number): 
 
   const link = result.data;
   const slug = requestedSlug
-    ? link.slugs.find((s) => s.slug === requestedSlug)
+    ? link.slugs.find((s) => s.slug === requestedSlug.toLowerCase())
     : link.slugs.find((s) => s.is_primary) ?? link.slugs[0];
 
   if (!slug) return json({ error: "Slug not found" }, 404);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -479,7 +479,7 @@ export class ShrtnrMCP extends McpAgent<Env, Record<string, never>, Props> {
         const link = result.data;
 
         const target = requestedSlug
-          ? link.slugs.find((s) => s.slug === requestedSlug)
+          ? link.slugs.find((s) => s.slug === requestedSlug.toLowerCase())
           : (link.slugs.find((s) => s.is_primary) ?? link.slugs[0]);
 
         if (!target) return fail("Slug not found");

--- a/src/services/bundle-management.ts
+++ b/src/services/bundle-management.ts
@@ -260,7 +260,8 @@ export async function getBundleAnalytics(
   const bundle = await BundleRepository.getById(env.DB, id);
   if (!bundle) return fail(404, "Bundle not found");
   const stats = await ClickRepository.getBundleStats(env.DB, id, range, undefined, opts?.filters);
-  return ok(stats!);
+  if (!stats) return fail(404, "Bundle not found");
+  return ok(stats);
 }
 
 export async function getBundleBreakdownPage(

--- a/src/services/link-management.ts
+++ b/src/services/link-management.ts
@@ -298,7 +298,9 @@ export async function setSlugPrimary(
   if (!slugObj) return fail(404, "Slug not found on this link");
 
   await SlugRepository.setPrimary(env.DB, linkId, slug);
-  return ok((await LinkRepository.getById(env.DB, linkId))!);
+  const updated = await LinkRepository.getById(env.DB, linkId);
+  if (!updated) return fail(404, "Link not found");
+  return ok(updated);
 }
 
 export async function disableSlug(


### PR DESCRIPTION
Weekly defect-hunting review across the app, API, and all three SDKs. Five fixes, each with a regression test that fails before and passes after.

## Fixes

**1. QR slug lookup was case-sensitive (`src/api/qr.ts`, `src/mcp/server.ts`)**
- Wrong: slugs are always stored lowercase (`link-management.ts` normalizes on write), and every other lookup path lowercases before comparing, but `handleLinkQr` and the `get_link_qr` MCP tool compared the raw `?slug=`/`slug` argument with `===`.
- Impact: a caller passing an uppercase/mixed-case slug value (which passes the route's own permissive `[a-zA-Z0-9_-]+` schema) got a spurious 404 for a slug that demonstrably exists on the link.
- Fix: lowercase the requested slug before comparing, matching every other lookup site.
- Test: `api-links.test.ts` and `mcp.test.ts` each add a case-mismatch regression test.

**2. `setSlugPrimary` returned 200/null instead of 404 on a concurrent link delete (`src/services/link-management.ts`)**
- Wrong: `SlugRepository.setPrimary` no-ops silently if the link/slug is gone; the service then force-unwrapped the trailing `getById` re-read with `!`.
- Impact: a delete landing between the membership check and the final read produced an HTTP 200 with a `null` body instead of a 404. Same TOCTOU class already fixed for bundle update/archive/unarchive/delete in a prior commit (551d205); this path was missed.
- Fix: check the re-read for null and return `fail(404, "Link not found")`.
- Test: `link-service.test.ts`, `vi.spyOn(LinkRepository, "getById")` simulates the race.

**3. `getBundleAnalytics` returned 200/null instead of 404 on a concurrent bundle delete (`src/services/bundle-management.ts`)**
- Wrong: the service's own `getById` check passes, then `ClickRepository.getBundleStats` runs its own independent `getById` internally and can legitimately return `null` if the bundle is deleted in between; the result was force-unwrapped with `!`.
- Impact: HTTP 200 with `null` body instead of 404, on `GET /bundles/:id/analytics` and the equivalent MCP tool.
- Fix: check for null and return `fail(404, "Bundle not found")`.
- Test: `bundle-service.test.ts`, mocks `ClickRepository.getBundleStats` to simulate the race.

**4/5. TS and Dart SDKs threw a raw parse exception instead of `ShrtnrError` on a non-JSON 2xx body**
- Wrong: both `HttpClient.request` (TS, `sdk/typescript/src/internal/http.ts`) and `requestJson` (Dart, `sdk/dart/lib/src/base_client.dart`) wrap `res.json()`/`jsonDecode` in try/catch on the *error* path but called it bare on the *success* path.
- Impact: an HTML error page or truncated body from an upstream proxy returning a 200 status threw a raw `SyntaxError`/`FormatException`, breaking the documented `catch (err) { if (err instanceof ShrtnrError) }` contract. Same bug class already fixed in the Python SDK (537a790); TS and Dart had it too.
- Fix: wrap in try/catch, raise `ShrtnrError(status, "Invalid JSON response: ...")`, mirroring the Python fix exactly.
- Test: `client.test.ts` (TS) and `client_test.dart` (Dart) each mock a `text/html` 2xx body.
- Note: Dart isn't installed in this execution environment, so `sdk/dart/test/client_test.dart` could not be run locally. The fix was traced manually against `jsonDecode`'s documented `FormatException` throw, and the test mirrors the exact fixture pattern of the adjacent "throws ShrtnrError on 4xx" test in the same group.

## Test suite

- Root: `72 test files / 1051 tests` passed.
- TS SDK: `68 tests` passed.
- Python SDK: unchanged, not re-run.
- Dart SDK: unchanged aside from the fix above; could not execute (no Dart runtime in this environment).

## Flagged for developer judgment (not fixed, no code changes)

- **Dart SDK README drift** (`sdk/dart/README.md`): quickstart examples pass `range: '7d'`/`accent: 'green'` as raw strings where the real methods require the `TimelineRange`/`BundleAccent` enums, so copy-pasted examples fail to compile. The `update()` examples document an `update(id, {field: value})` shape but the real signature is `update(Link)`/`update(Bundle)` (whole-object). Exported type names `DateClickCount`/`SlugClickCount` don't match the real `DateCount`/`SlugCount`. All four are docs-only; no regression test is possible for markdown examples, so left for a developer to fix the README text.
- **Python SDK async test-coverage gap**: `_base.py`'s `parse_json_response` fix (537a790) is exercised only by sync tests in `test_client.py`; `test_async_client.py` has no equivalent non-JSON-2xx or `qr(size=...)` test, even though both paths share the same underlying code. Not a live bug today, but a future divergence of the async path would go uncaught.
- **Dependency drift**: `typescript` is one major behind (6.x → 7.0.2) in both the root app and TS SDK; `@cloudflare/workers-types` is one major behind (4.x → 5.x). `yarn audit` reports 19 (root) / 7 (TS SDK) vulnerabilities, all in transitive dev/test tooling (`vite`/`esbuild` via `vitest`) or bundled into `@modelcontextprotocol/sdk`'s Express transport (`fast-uri`, `ip-address`, `qs`) — none critical, none with a drop-in safe patch identified. Worth a planned major-version bump pass, not an urgent patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4y1EW3mEZqHENRoh8TFGu)_