### PR TITLE
Show the date on hover over clicks-over-time chart points

### DIFF
--- a/src/__tests__/unit/big-chart.test.ts
+++ b/src/__tests__/unit/big-chart.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import { jsx } from "hono/jsx";
-import { BigChart } from "../../components/big-chart";
+import { BigChart, formatBucketLabel } from "../../components/big-chart";
 import { createTranslateFn } from "../../i18n";
 import type { TimelineRange } from "../../types";
 
@@ -11,6 +11,14 @@ const t = createTranslateFn("en");
 
 function render(values: number[], range: TimelineRange = "30d"): string {
   return String(jsx(BigChart, { values, range, t, id: "test" }));
+}
+
+function renderWithDates(
+  values: number[],
+  dates: string[],
+  range: TimelineRange = "30d",
+): string {
+  return String(jsx(BigChart, { values, range, t, id: "test", dates, lang: "en" }));
 }
 
 describe("BigChart incomplete-period treatment", () => {
@@ -55,5 +63,49 @@ describe("BigChart incomplete-period treatment", () => {
     const out = render([]);
     expect(out).toContain(t("linkDetail.noClickData"));
     expect(out).not.toContain("stroke-dasharray");
+  });
+});
+
+describe("BigChart per-point date tooltips", () => {
+  it("renders a hover band with the formatted date for every point when dates are supplied", () => {
+    const out = renderWithDates(
+      [10, 20, 30],
+      ["2026-07-14", "2026-07-15", "2026-07-16"],
+    );
+    // One transparent hover band per point.
+    expect(out.match(/<rect[^>]*fill="transparent"/g)?.length).toBe(3);
+    // Each band exposes its date through a native <title> tooltip.
+    expect(out).toContain("<title>Jul 14, 2026</title>");
+    expect(out).toContain("<title>Jul 15, 2026</title>");
+  });
+
+  it("marks the final point's tooltip as the in-progress period", () => {
+    const out = renderWithDates([10, 20], ["2026-07-15", "2026-07-16"]);
+    expect(out).toContain(`Jul 16, 2026 (${t("linkDetail.todayPartial")})`);
+  });
+
+  it("does not render hover bands when no dates are supplied", () => {
+    const out = render([10, 20, 30]);
+    expect(out).not.toContain('fill="transparent"');
+  });
+
+  it("ignores a dates array whose length does not match the values", () => {
+    const out = renderWithDates([10, 20, 30], ["2026-07-16"]);
+    expect(out).not.toContain('fill="transparent"');
+  });
+});
+
+describe("formatBucketLabel", () => {
+  it("formats a daily bucket with day, month, and year", () => {
+    expect(formatBucketLabel("2026-07-16", "en")).toBe("Jul 16, 2026");
+  });
+
+  it("formats a monthly bucket with month and year only", () => {
+    expect(formatBucketLabel("2026-07", "en")).toBe("Jul 2026");
+  });
+
+  it("formats an hourly bucket with the hour in UTC", () => {
+    expect(formatBucketLabel("2026-07-16 09", "en")).toContain("Jul 16, 2026");
+    expect(formatBucketLabel("2026-07-16 09", "en")).toContain("09:00");
   });
 });

--- a/src/__tests__/unit/big-chart.test.ts
+++ b/src/__tests__/unit/big-chart.test.ts
@@ -68,20 +68,25 @@ describe("BigChart incomplete-period treatment", () => {
 
 describe("BigChart per-point date tooltips", () => {
   it("renders a hover band with the formatted date for every point when dates are supplied", () => {
-    const out = renderWithDates(
-      [10, 20, 30],
-      ["2026-07-14", "2026-07-15", "2026-07-16"],
-    );
+    const dates = ["2026-07-14", "2026-07-15", "2026-07-16"];
+    const out = renderWithDates([10, 20, 30], dates);
     // One transparent hover band per point.
     expect(out.match(/<rect[^>]*fill="transparent"/g)?.length).toBe(3);
-    // Each band exposes its date through a native <title> tooltip.
-    expect(out).toContain("<title>Jul 14, 2026</title>");
-    expect(out).toContain("<title>Jul 15, 2026</title>");
+    // Each band exposes its date through a native <title> tooltip. Expected text
+    // comes from the formatter, so an ICU version that punctuates dates
+    // differently cannot fail this test; formatBucketLabel pins its own output
+    // in the describe block below.
+    expect(out).toContain(`<title>${formatBucketLabel(dates[0], "en")}</title>`);
+    expect(out).toContain(`<title>${formatBucketLabel(dates[1], "en")}</title>`);
   });
 
   it("marks the final point's tooltip as the in-progress period", () => {
     const out = renderWithDates([10, 20], ["2026-07-15", "2026-07-16"]);
-    expect(out).toContain(`Jul 16, 2026 (${t("linkDetail.todayPartial")})`);
+    expect(out).toContain(
+      `${formatBucketLabel("2026-07-16", "en")} (${t("linkDetail.todayPartial")})`,
+    );
+    // Only the final point is annotated; earlier bands carry a bare date.
+    expect(out).toContain(`<title>${formatBucketLabel("2026-07-15", "en")}</title>`);
   });
 
   it("does not render hover bands when no dates are supplied", () => {
@@ -95,17 +100,38 @@ describe("BigChart per-point date tooltips", () => {
   });
 });
 
+// These assert the components that carry meaning: month name, day, year, and
+// granularity. Ordering and punctuation come from ICU and have shifted between
+// runtime versions, so full-string equality would fail on a Node upgrade while
+// the behavior stayed correct. A wrong month index and a wrong granularity
+// branch both still fail these checks (verified by mutating the source).
+// `timeZone: "UTC"` is not covered: the workers pool runs in UTC, so UTC and
+// local formatting coincide here. It stays load-bearing in the browser, where
+// client.ts renders the same labels against the viewer's zone.
 describe("formatBucketLabel", () => {
   it("formats a daily bucket with day, month, and year", () => {
-    expect(formatBucketLabel("2026-07-16", "en")).toBe("Jul 16, 2026");
+    const out = formatBucketLabel("2026-07-16", "en");
+    expect(out).toContain("Jul");
+    expect(out).toContain("16");
+    expect(out).toContain("2026");
+    // No time component on a daily bucket.
+    expect(out).not.toMatch(/\d{1,2}:\d{2}/);
   });
 
   it("formats a monthly bucket with month and year only", () => {
-    expect(formatBucketLabel("2026-07", "en")).toBe("Jul 2026");
+    const out = formatBucketLabel("2026-07", "en");
+    expect(out).toContain("Jul");
+    expect(out).toContain("2026");
+    // A monthly bucket is built on the 1st. Falling through to the daily branch
+    // would render that day, so the two labels must not match.
+    expect(out).not.toBe(formatBucketLabel("2026-07-01", "en"));
   });
 
   it("formats an hourly bucket with the hour in UTC", () => {
-    expect(formatBucketLabel("2026-07-16 09", "en")).toContain("Jul 16, 2026");
-    expect(formatBucketLabel("2026-07-16 09", "en")).toContain("09:00");
+    const out = formatBucketLabel("2026-07-16 09", "en");
+    expect(out).toContain("Jul");
+    expect(out).toContain("16");
+    expect(out).toContain("2026");
+    expect(out).toContain("09:00");
   });
 });

--- a/src/__tests__/unit/sparkline-labels.test.ts
+++ b/src/__tests__/unit/sparkline-labels.test.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { sparklineBucketLabels } from "../../db/click-repository";
+
+// 2026-07-16 12:00:00 UTC.
+const TS = Math.floor(Date.UTC(2026, 6, 16, 12, 0, 0) / 1000);
+
+describe("sparklineBucketLabels", () => {
+  it("emits one label per bucket, oldest first, current period last", () => {
+    const labels = sparklineBucketLabels("7d", TS);
+    expect(labels).toHaveLength(7);
+    expect(labels[labels.length - 1]).toBe("2026-07-16");
+    expect(labels[0]).toBe("2026-07-10");
+    // Chronological, ascending.
+    expect([...labels].sort()).toEqual(labels);
+  });
+
+  it("uses hourly labels for the 24h range", () => {
+    const labels = sparklineBucketLabels("24h", TS);
+    expect(labels).toHaveLength(24);
+    expect(labels[labels.length - 1]).toBe("2026-07-16 12");
+  });
+
+  it("uses monthly labels for the 1y and all ranges", () => {
+    for (const range of ["1y", "all"] as const) {
+      const labels = sparklineBucketLabels(range, TS);
+      expect(labels).toHaveLength(12);
+      expect(labels[labels.length - 1]).toBe("2026-07");
+    }
+  });
+
+  it("produces 30 daily labels for the 30d range", () => {
+    const labels = sparklineBucketLabels("30d", TS);
+    expect(labels).toHaveLength(30);
+    expect(labels[labels.length - 1]).toBe("2026-07-16");
+    // 30 buckets: the current day plus the 29 preceding days.
+    expect(labels[0]).toBe("2026-06-17");
+  });
+});

--- a/src/admin/widgets/dashboard/timeline.tsx
+++ b/src/admin/widgets/dashboard/timeline.tsx
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AdminWidget } from "../types";
 import type { Env, TimelineRange } from "../../../types";
-import { ClickRepository } from "../../../db";
+import { ClickRepository, sparklineBucketLabels } from "../../../db";
 import { BigChart } from "../../../components/big-chart";
 import { parseRangeParam } from "./_range";
 
 interface TimelineData {
   range: TimelineRange;
   values: number[];
+  labels: string[];
 }
 
 /**
@@ -24,13 +25,9 @@ export const timelineWidget: AdminWidget<{ range: TimelineRange }, TimelineData>
   cache: { ttl: 30 },
   params: parseRangeParam,
   async load(env: Env, ctx, { range }): Promise<TimelineData> {
-    const values = await ClickRepository.getSparkline(
-      env.DB,
-      range,
-      Math.floor(Date.now() / 1000),
-      ctx.filters,
-    );
-    return { range, values };
+    const ts = Math.floor(Date.now() / 1000);
+    const values = await ClickRepository.getSparkline(env.DB, range, ts, ctx.filters);
+    return { range, values, labels: sparklineBucketLabels(range, ts) };
   },
   render(d, ctx) {
     const t = ctx.t;
@@ -41,7 +38,14 @@ export const timelineWidget: AdminWidget<{ range: TimelineRange }, TimelineData>
           <span class="timeline-range-pill">{t(`range.long.${d.range}` as const)}</span>
         </div>
         <div class="timeline-chart">
-          <BigChart values={d.values} range={d.range} t={t} id="dash-bigchart" />
+          <BigChart
+            values={d.values}
+            range={d.range}
+            t={t}
+            id="dash-bigchart"
+            dates={d.labels}
+            lang={ctx.lang}
+          />
         </div>
       </>
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -1024,6 +1024,26 @@ function fmtLabel(label, range) {
   return monthName(parseInt(parts[1], 10)) + ' ' + parts[0].slice(2);
 }
 
+// Humanizes a canonical bucket label ("YYYY-MM", "YYYY-MM-DD", or
+// "YYYY-MM-DD HH") into a full, locale-aware date for point tooltips. Buckets
+// are UTC, so format in UTC to match the axis offsets.
+function fmtBucketDate(label) {
+  var split = label.split(' ');
+  var d = split[0].split('-');
+  var y = parseInt(d[0], 10), mo = parseInt(d[1], 10);
+  if (d.length < 3) {
+    var dtM = new Date(Date.UTC(y, mo - 1, 1));
+    return dtM.toLocaleDateString(UI_LANG, { year: 'numeric', month: 'short', timeZone: 'UTC' });
+  }
+  var day = parseInt(d[2], 10);
+  if (split.length > 1) {
+    var dtH = new Date(Date.UTC(y, mo - 1, day, parseInt(split[1], 10)));
+    return dtH.toLocaleString(UI_LANG, { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', timeZone: 'UTC' });
+  }
+  var dtD = new Date(Date.UTC(y, mo - 1, day));
+  return dtD.toLocaleDateString(UI_LANG, { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
 function renderTimeline(data) {
   var container = document.getElementById('timeline-chart');
   if (!data.buckets || data.buckets.length === 0) {
@@ -1111,6 +1131,20 @@ function renderTimeline(data) {
       var label = i === n - 1 ? t('linkDetail.today') : fmtLabel(buckets[i].label, data.range);
       parts.push('<text x="' + pts[i][0].toFixed(1) + '" y="' + (h - 6) + '" font-size="9" fill="var(--color-text-subtle)" text-anchor="middle" font-family="var(--font-family-mono)">' + esc(label) + '</text>');
     }
+  }
+
+  // Invisible per-point hover bands. Each spans its column full-height so the
+  // cursor need not hit the tiny dot; the native <title> shows the point's
+  // date. Rendered last so they sit on top and win the hover.
+  var bandW = n > 1 ? stepX : innerW;
+  for (var i = 0; i < n; i++) {
+    var x0 = pts[i][0] - bandW / 2;
+    var x1 = pts[i][0] + bandW / 2;
+    if (x0 < pad.l) x0 = pad.l;
+    if (x1 > w - pad.r) x1 = w - pad.r;
+    var date = fmtBucketDate(buckets[i].label);
+    var title = i === n - 1 ? date + ' (' + t('linkDetail.todayPartial') + ')' : date;
+    parts.push('<rect x="' + x0.toFixed(1) + '" y="' + pad.t + '" width="' + (x1 - x0).toFixed(1) + '" height="' + innerH + '" fill="transparent" pointer-events="all"><title>' + esc(title) + '</title></rect>');
   }
 
   parts.push('</svg>');

--- a/src/components/big-chart.tsx
+++ b/src/components/big-chart.tsx
@@ -10,7 +10,45 @@ type BigChartProps = {
   range: TimelineRange;
   t: TranslateFn;
   id?: string;
+  /**
+   * Canonical bucket labels aligned to `values` (see sparklineBucketLabels).
+   * When present, each point gets a hover band with the date as a tooltip.
+   */
+  dates?: string[];
+  /** BCP-47 locale for date formatting; defaults to "en". */
+  lang?: string;
 };
+
+/**
+ * Humanizes a canonical bucket label (`YYYY-MM`, `YYYY-MM-DD`, or
+ * `YYYY-MM-DD HH`) into a locale-aware date string. Buckets are UTC, so the
+ * output is formatted in UTC to line up with the axis offsets.
+ */
+export function formatBucketLabel(label: string, lang: string): string {
+  const [datePart, hourPart] = label.split(" ");
+  const parts = datePart.split("-").map(Number);
+  const [y, m, d] = parts;
+  if (d === undefined) {
+    // Monthly bucket: "YYYY-MM".
+    const dt = new Date(Date.UTC(y, m - 1, 1));
+    return dt.toLocaleDateString(lang, { year: "numeric", month: "short", timeZone: "UTC" });
+  }
+  if (hourPart !== undefined) {
+    // Hourly bucket: "YYYY-MM-DD HH".
+    const dt = new Date(Date.UTC(y, m - 1, d, Number(hourPart)));
+    return dt.toLocaleString(lang, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: "UTC",
+    });
+  }
+  // Daily (or weekly) bucket: "YYYY-MM-DD".
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.toLocaleDateString(lang, { year: "numeric", month: "short", day: "numeric", timeZone: "UTC" });
+}
 
 const W = 800;
 const H = 220;
@@ -40,7 +78,7 @@ function offsetLabel(range: TimelineRange, i: number, n: number): string {
   return `-${fromEnd}d`;
 }
 
-export const BigChart: FC<BigChartProps> = ({ values, range, t, id }) => {
+export const BigChart: FC<BigChartProps> = ({ values, range, t, id, dates, lang }) => {
   const n = values.length;
   if (n === 0) {
     return <div class="empty-card-hint">{t("linkDetail.noClickData")}</div>;
@@ -195,6 +233,36 @@ export const BigChart: FC<BigChartProps> = ({ values, range, t, id }) => {
           </text>
         ) : null,
       )}
+      {/*
+        Invisible per-point hover bands. Each spans its column full-height so
+        the cursor need not land on the tiny dot; the native SVG <title> shows
+        the date the point represents. Rendered last so they sit on top of the
+        line and dots and win the hover. Only emitted when dates are supplied.
+      */}
+      {dates && dates.length === n
+        ? pts.map((p, i) => {
+            const bandW = n > 1 ? stepX : innerW;
+            let x0 = p[0] - bandW / 2;
+            let x1 = p[0] + bandW / 2;
+            if (x0 < PAD.l) x0 = PAD.l;
+            if (x1 > W - PAD.r) x1 = W - PAD.r;
+            const label = formatBucketLabel(dates[i], lang ?? "en");
+            const title = i === n - 1 ? `${label} (${t("linkDetail.todayPartial")})` : label;
+            return (
+              <rect
+                key={`hit-${i}`}
+                x={x0.toFixed(1)}
+                y={PAD.t}
+                width={(x1 - x0).toFixed(1)}
+                height={innerH}
+                fill="transparent"
+                pointer-events="all"
+              >
+                <title>{title}</title>
+              </rect>
+            );
+          })
+        : null}
     </svg>
   );
 };

--- a/src/db/click-repository.ts
+++ b/src/db/click-repository.ts
@@ -1669,6 +1669,21 @@ function fillSparkline(
   return out;
 }
 
+/**
+ * Canonical bucket labels for a getSparkline series, in the same order as the
+ * values it returns (oldest first, current period last). Callers pair these
+ * with the values to attach a per-point date to the chart; the label format
+ * matches sparkLabelAt (`YYYY-MM`, `YYYY-MM-DD`, or `YYYY-MM-DD HH`).
+ */
+export function sparklineBucketLabels(range: TimelineRange, ts: number): string[] {
+  const spec = getBucketSpec(range, ts);
+  const out: string[] = [];
+  for (let i = spec.buckets - 1; i >= 0; i--) {
+    out.push(sparkLabelAt(range, ts - i * spec.stepSec));
+  }
+  return out;
+}
+
 function fillBuckets(
   range: TimelineRange,
   dataMap: Map<string, number>,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -3,7 +3,7 @@
 
 export { LinkRepository } from "./link-repository";
 export { SlugRepository } from "./slug-repository";
-export { ClickRepository } from "./click-repository";
+export { ClickRepository, sparklineBucketLabels } from "./click-repository";
 export type { BreakdownDimension } from "./click-repository";
 export type { ClickFilters, SlugClickCountOptions } from "./filters";
 export { clickFilterSql, slugClickCountSql } from "./filters";

--- a/src/pages/bundle-detail.tsx
+++ b/src/pages/bundle-detail.tsx
@@ -73,6 +73,7 @@ export const BundleDetailPage: FC<Props> = ({ stats, identity, t, lang, range })
   const now = Math.floor(Date.now() / 1000);
 
   const timelineValues = stats.timeline.buckets.map((x) => x.count);
+  const timelineLabels = stats.timeline.buckets.map((x) => x.label);
 
   const countryTotal = stats.countries.reduce((s, c) => s + c.count, 0);
   const devTotal = stats.devices.reduce((s, c) => s + c.count, 0);
@@ -274,7 +275,7 @@ export const BundleDetailPage: FC<Props> = ({ stats, identity, t, lang, range })
             </div>
             <div class="timeline-chart">
               {timelineValues.length > 0 ? (
-                <BigChart values={timelineValues} range={range} t={t} id="bundle-bigchart" />
+                <BigChart values={timelineValues} range={range} t={t} id="bundle-bigchart" dates={timelineLabels} lang={lang} />
               ) : (
                 <div class="empty-card-hint">{t("linkDetail.noClickData")}</div>
               )}


### PR DESCRIPTION
## What

Hovering a point on the "Clicks over time" chart now reveals the exact date it represents. Previously the only time reference was the `-14d`-style X-axis offset, which tells you a spike was "two weeks ago" but not the actual calendar date. Now the date is one hover away.

## How

Each point gets an invisible, full-height hover band spanning its column, so the cursor does not have to land precisely on the small dot. The band carries the date in a native SVG `<title>` tooltip (no JS tooltip layer, no new dependencies). The final point's tooltip is annotated as the in-progress period.

Dates are formatted in UTC to line up with the axis, and the granularity follows the range: day for 7d/30d/90d, hour for 24h, month for 1y/all.

## Changes

- `components/big-chart.tsx`: accept `dates`/`lang` props, render the hover bands, and add `formatBucketLabel` to humanize canonical bucket labels (`YYYY-MM`, `YYYY-MM-DD`, `YYYY-MM-DD HH`).
- `db/click-repository.ts`: export `sparklineBucketLabels`, the label series aligned to `getSparkline` values, and re-export it from the db barrel.
- `admin/widgets/dashboard/timeline.tsx`: pass the labels through to the dashboard chart (the graph in the request).
- `pages/bundle-detail.tsx`: feed the existing bucket labels through as dates.
- `client.ts`: mirror the bands in the client-drawn link-detail chart for consistency.

## Tests

- `big-chart.test.ts`: hover bands render one per point with the formatted date, the final point is marked in-progress, no bands render without dates or on a length mismatch, plus `formatBucketLabel` cases for daily/monthly/hourly.
- `sparkline-labels.test.ts`: `sparklineBucketLabels` alignment, ordering, and per-range granularity.

Full suite (1074 tests) passes and `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPBnVRpW7yYUPw4aiG5fG8)_