### PR TITLE
Weekly defect review: bundle-link race, pagination clamp, SDK case-conversion, MCP doc accuracy

### DIFF
--- a/sdk/typescript/src/internal/case.ts
+++ b/sdk/typescript/src/internal/case.ts
@@ -14,14 +14,21 @@ export function toSnake(s: string): string {
   return s.replace(/([A-Z])/g, (c) => `_${c.toLowerCase()}`);
 }
 
+/** True for plain `{}`/`Object.create(null)` objects, false for Date, Map, and other class instances. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 /** Recursively transform all object keys from snake_case to camelCase. */
 export function keysToCamel(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(keysToCamel);
   }
-  if (value !== null && typeof value === "object") {
+  if (isPlainObject(value)) {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    for (const [k, v] of Object.entries(value)) {
       out[toCamel(k)] = keysToCamel(v);
     }
     return out;
@@ -34,9 +41,9 @@ export function keysToSnake(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(keysToSnake);
   }
-  if (value !== null && typeof value === "object") {
+  if (isPlainObject(value)) {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    for (const [k, v] of Object.entries(value)) {
       out[toSnake(k)] = keysToSnake(v);
     }
     return out;

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -249,6 +249,17 @@ describe("Case transformation", () => {
     expect(body["link_id"]).toBe(99);
     expect(body["linkId"]).toBeUndefined();
   });
+
+  it("does not flatten a non-plain-object value (e.g. Date) into {}", async () => {
+    mockFetch(201, { id: 1, url: "https://example.com", label: null, created_at: 1000, expires_at: null, created_via: null, created_by: "u", total_clicks: 0, slugs: [] });
+    const expiresAt = new Date("2030-01-01T00:00:00Z");
+    // expiresAt is typed as number (a unix timestamp); this cast simulates a
+    // plain-JS caller passing a Date, which used to be silently flattened to {}.
+    await client().links.create({ url: "https://example.com", expiresAt: expiresAt as unknown as number });
+    const { init } = lastCall();
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body["expires_at"]).toBe(expiresAt.toISOString());
+  });
 });
 
 // ============================================================

--- a/src/__tests__/handler/mcp.test.ts
+++ b/src/__tests__/handler/mcp.test.ts
@@ -16,6 +16,8 @@ import {
 } from "../../services/link-management";
 import { ShrtnrMCP } from "../../mcp/server";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 beforeAll(applyMigrations);
 beforeEach(resetData);
@@ -663,10 +665,25 @@ describe("MCP tool descriptions", () => {
     const agent = Object.create(ShrtnrMCP.prototype) as ShrtnrMCP;
     agent.server = new McpServer({ name: "shrtnr", version: "test" });
     await agent.init();
-    const tools = (agent.server as unknown as {
-      _registeredTools: Record<string, { description?: string }>;
-    })._registeredTools;
-    expect(tools.list_bundles.description).not.toMatch(/owned by the caller/i);
-    expect(tools.list_bundles.description).toMatch(/visible to any authenticated caller/i);
+
+    // Read the descriptions back over the wire protocol (tools/list) rather
+    // than off the server's internals, so the test depends only on the
+    // contract an MCP client actually sees.
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "test" });
+    await Promise.all([
+      client.connect(clientTransport),
+      agent.server.connect(serverTransport),
+    ]);
+
+    try {
+      const { tools } = await client.listTools();
+      const listBundles = tools.find((t) => t.name === "list_bundles");
+      expect(listBundles).toBeDefined();
+      expect(listBundles?.description).not.toMatch(/owned by the caller/i);
+      expect(listBundles?.description).toMatch(/visible to any authenticated caller/i);
+    } finally {
+      await client.close();
+    }
   });
 });

--- a/src/__tests__/handler/mcp.test.ts
+++ b/src/__tests__/handler/mcp.test.ts
@@ -15,6 +15,7 @@ import {
   searchLinks,
 } from "../../services/link-management";
 import { ShrtnrMCP } from "../../mcp/server";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 beforeAll(applyMigrations);
 beforeEach(resetData);
@@ -647,5 +648,25 @@ describe("MCP error surface", () => {
     // The validation error mentions the tool name and the failing field.
     expect(result?.content?.[0]?.text).toMatch(/create_link/);
     expect(result?.content?.[0]?.text?.toLowerCase()).toMatch(/url|required|invalid/);
+  });
+});
+
+// ---- MCP tool description accuracy ----
+// Regression: list_bundles' description claimed bundles are "owned by the
+// caller", but listBundles() is deliberately open-read across owners (see
+// bundle-management.ts). A tool description that overstates privacy could
+// mislead an agent into disclosing another user's bundles while believing
+// the results were caller-scoped.
+
+describe("MCP tool descriptions", () => {
+  it("list_bundles does not claim caller-owned scoping", async () => {
+    const agent = Object.create(ShrtnrMCP.prototype) as ShrtnrMCP;
+    agent.server = new McpServer({ name: "shrtnr", version: "test" });
+    await agent.init();
+    const tools = (agent.server as unknown as {
+      _registeredTools: Record<string, { description?: string }>;
+    })._registeredTools;
+    expect(tools.list_bundles.description).not.toMatch(/owned by the caller/i);
+    expect(tools.list_bundles.description).toMatch(/visible to any authenticated caller/i);
   });
 });

--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -173,4 +173,28 @@ describe("Links listing page", () => {
     const html = await res.text();
     expect(html).toMatch(/1\s*[–-]\s*25\s+of\s+30/);
   });
+
+  it("clamps a negative page param instead of producing an empty, out-of-range slice", async () => {
+    for (let i = 0; i < 30; i++) {
+      await LinkRepository.create(env.DB, {
+        url: `https://example${i}.com`,
+        slug: `s${i}`,
+      });
+    }
+    const res = await SELF.fetch(req("/_/admin/links?page=-3"));
+    const html = await res.text();
+    expect(html).toMatch(/1\s*[–-]\s*25\s+of\s+30/);
+  });
+
+  it("clamps a negative per_page param instead of an inverted slice range", async () => {
+    for (let i = 0; i < 30; i++) {
+      await LinkRepository.create(env.DB, {
+        url: `https://example${i}.com`,
+        slug: `s${i}`,
+      });
+    }
+    const res = await SELF.fetch(req("/_/admin/links?per_page=-5"));
+    const html = await res.text();
+    expect(html).toMatch(/1\s*[–-]\s*1\s+of\s+30/);
+  });
 });

--- a/src/__tests__/service/bundle-service.test.ts
+++ b/src/__tests__/service/bundle-service.test.ts
@@ -172,6 +172,23 @@ describe("addLinkToBundle / removeLinkFromBundle", () => {
     if (!res.ok) expect(res.status).toBe(404);
   });
 
+  it("returns 404 rather than 500 when a concurrent delete removes the bundle between the existence check and the insert", async () => {
+    // The pre-read getById() can pass, then a concurrent DELETE wins the race
+    // before this call's own INSERT runs. INSERT OR IGNORE does not suppress
+    // FK violations, so without a try/catch the D1 error would propagate as
+    // an unhandled 500 instead of the 404 every other race in this codebase returns.
+    const link = await LinkRepository.create(env.DB, { url: "https://a.com", slug: "aaa", createdBy: "a@b" });
+    const b = await BundleRepository.create(env.DB, { name: "B", createdBy: "a@b" });
+
+    const spy = vi.spyOn(BundleRepository, "addLink").mockRejectedValueOnce(
+      new Error("D1_ERROR: FOREIGN KEY constraint failed"),
+    );
+    const res = await svc.addLinkToBundle(e, b.id, link.id, "a@b").finally(() => spy.mockRestore());
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.status).toBe(404);
+  });
+
   it("removes a link from a bundle", async () => {
     const link = await LinkRepository.create(env.DB, { url: "https://a.com", slug: "aaa", createdBy: "a@b" });
     const b = await BundleRepository.create(env.DB, { name: "B", createdBy: "a@b" });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -231,8 +231,8 @@ app.get("/_/admin/links", async (c) => {
     : await listLinks(c.env, { withDeltaRange: range, filters, range });
   const links = linksResult.ok ? linksResult.data : [];
   const sort = c.req.query("sort") || "recent";
-  const page = parseInt(c.req.query("page") || "1", 10) || 1;
-  const perPage = parseInt(c.req.query("per_page") || "25", 10) || 25;
+  const page = Math.max(1, parseInt(c.req.query("page") || "1", 10) || 1);
+  const perPage = Math.max(1, parseInt(c.req.query("per_page") || "25", 10) || 25);
   const filterParam = c.req.query("filter");
   const legacyShowDisabled = c.req.query("show_disabled") === "1";
   const filter = filterParam === "disabled" || filterParam === "all" || filterParam === "active"

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -724,7 +724,7 @@ export class ShrtnrMCP extends McpAgent<Env, Record<string, never>, Props> {
       {
         title: "List bundles",
         description:
-          "List bundles owned by the caller. Bundles group related links so you can see combined click stats across them. Totals, sparklines, and `delta_pct` are scoped to the requested range; reuse the same range across follow-ups to keep numbers comparable. Defaults to the user's `default_range` setting (or 30d). Response includes `range_used`. Use `filter` to control which archival state is returned.",
+          "List all bundles visible to any authenticated caller. Bundles group related links so you can see combined click stats across them. Totals, sparklines, and `delta_pct` are scoped to the requested range; reuse the same range across follow-ups to keep numbers comparable. Defaults to the user's `default_range` setting (or 30d). Response includes `range_used`. Use `filter` to control which archival state is returned.",
         inputSchema: {
           filter: z
             .enum(["active", "archived", "all"])

--- a/src/services/bundle-management.ts
+++ b/src/services/bundle-management.ts
@@ -226,7 +226,18 @@ export async function addLinkToBundle(
   if (!bundle) return fail(404, "Bundle not found");
   const link = await LinkRepository.getById(env.DB, linkId);
   if (!link) return fail(404, "Link not found");
-  await BundleRepository.addLink(env.DB, bundleId, linkId);
+  try {
+    await BundleRepository.addLink(env.DB, bundleId, linkId);
+  } catch (e) {
+    // A concurrent delete of the bundle or link between the existence checks
+    // above and the INSERT trips the bundle_links FK constraint. INSERT OR
+    // IGNORE does not suppress FK violations, so surface it as 404 rather
+    // than letting the D1 error propagate as a 500.
+    if (e instanceof Error && e.message.includes("FOREIGN KEY constraint failed")) {
+      return fail(404, "Bundle or link not found");
+    }
+    throw e;
+  }
   return ok({ added: true });
 }
 


### PR DESCRIPTION
Weekly defect-hunting review of the app, API, and all three SDKs. Six parallel review passes (backend, frontend, TypeScript SDK, Python SDK, Dart SDK, dependency drift) turned up four fixable defects, all fixed here with regression tests, plus three items left as comments for developer judgment.

## Fixed

### 1. `addLinkToBundle` returned 500 instead of 404 under a concurrent-delete race
- **What was wrong**: `BundleRepository.addLink` uses `INSERT OR IGNORE`, which does not suppress foreign-key constraint violations (only UNIQUE/NOT NULL/CHECK). If a bundle or link is deleted between `addLinkToBundle`'s existence checks and the INSERT, the FK constraint on `bundle_links` trips and D1 throws.
- **Impact**: An unhandled 500 instead of the 404 every other concurrent-delete race in this codebase returns (`removeSlug`, `deleteLink`, `setSlugPrimary`, etc. all handle this pattern).
- **Fix**: `src/services/bundle-management.ts` — catch the FK violation and map it to `fail(404, ...)`, mirroring the existing UNIQUE-violation handling in `addCustomSlugToLink`.
- **Test**: `src/__tests__/service/bundle-service.test.ts` — simulates the race via `vi.spyOn(BundleRepository, "addLink").mockRejectedValueOnce(...)`; fails before the fix (uncaught error), passes after (404).

### 2. Negative `page`/`per_page` on the links listing produced nonsensical pagination
- **What was wrong**: `parseInt(...) || fallback` only catches `0`/`NaN`, not negative integers, in `src/index.tsx`.
- **Impact**: `?page=-3` on a listing with more than a page of links renders an empty table (negative slice bounds) with a nonsensical "-99–-75 of 60" summary; negative `per_page` produces an inverted slice range.
- **Fix**: Clamp both to a minimum of 1 at the parsing site.
- **Test**: `src/__tests__/page/links-page.test.ts` — two new cases (`page=-3`, `per_page=-5`) against a 30-link fixture; fail before the fix, pass after.

### 3. TypeScript SDK silently flattened non-plain-object body values to `{}`
- **What was wrong**: `keysToSnake`/`keysToCamel` in `sdk/typescript/src/internal/case.ts` recursed into anything with `typeof value === "object"`, including `Date` and other class instances. `Object.entries()` on a `Date` returns no own enumerable properties, so any such value passed for a body field was silently flattened to `{}` on the wire.
- **Impact**: A plain-JS caller passing a `Date` for a field like `expiresAt` (typed as `number` in this SDK, but a natural mistake) would send `{}` instead of a serializable value, with no error.
- **Fix**: Restrict recursion to plain objects (`Object.prototype` or `null` prototype); class instances now pass through untouched for `JSON.stringify` to serialize normally.
- **Test**: `sdk/typescript/tests/client.test.ts` — asserts a `Date` passed for `expiresAt` serializes to its ISO string, not `{}`.
- **SDK parity note**: TypeScript-only change. Python and Dart don't have an equivalent generic recursive case-conversion helper (Python models use snake_case natively; Dart uses explicit `fromJson`/`toJson`), so this bug class doesn't exist in the other two SDKs — confirmed by grep, no parity gap.

### 4. MCP `list_bundles` tool description contradicted its actual open-read behavior
- **What was wrong**: The tool description said "List bundles **owned by the caller**," but `listBundles()` is deliberately open-read across all owners (matching the link/slug model) — the description was simply wrong.
- **Impact**: An MCP client (an AI agent) could be misled into treating results as caller-private and relaying another user's bundle data (names, descriptions, click stats) under that false assumption.
- **Fix**: `src/mcp/server.ts` — corrected the description to match `list_links`' phrasing for the same open-read model. Doc-only, no behavior change.
- **Test**: `src/__tests__/handler/mcp.test.ts` — instantiates `ShrtnrMCP`, registers tools, and asserts the `list_bundles` description no longer claims caller-owned scoping.

## Test plan
- [x] Full root suite: 1067 passed (1063 baseline + 4 new)
- [x] TypeScript SDK suite: 73 passed (72 baseline + 1 new)
- [x] Python SDK suite: 94 passed, unchanged
- [x] Each new test independently verified to fail before its fix and pass after

## Flagged for developer judgment (not fixed here)

- **Dart SDK — `base_client.dart:74,118`**: `response.body.isEmpty` (in `requestJson`) and the entire 2xx path of `requestText` decode response bytes to a string *outside* the try/catch that wraps JSON-parse failures into `ShrtnrError`. A response with a declared UTF-8 charset and invalid byte sequences would throw a raw `FormatException`, bypassing the SDK's error contract — the same failure class the recent 2xx-JSON-parse fix targeted, one step earlier (byte-decode vs. JSON-syntax). Not fixed here: this sandbox has no Dart toolchain, so I can't compile or run `dart test` to prove a fix.
- **Python SDK — `tests/test_e2e.py:34-38`**: the module-scoped sync `client` fixture never closes its `httpx.Client`, unlike the `async_client` fixture in the same file which does `try/finally` cleanup with `aclose()`. Low-impact (e2e-only, process exits after the run) and only meaningfully testable against a live `wrangler dev` instance, which isn't available here.
- **`src/pages/layout.tsx:79,97,99,122`**: `alt="shrtnr."` and `alt`/`title="Oddbit"` are hardcoded rather than routed through `t()`, technically violating the project's i18n rule. Not a functional bug — the brand name is identical across all three locale files — so it's a compliance/style item rather than a defect; left for a judgment call on whether it's worth new translation keys for an unchanging brand string.

## Clean
- Dependency/version drift audit across root `package.json` and all three SDK manifests: nothing outdated or flagged, matches the recent "upgrade dependencies" PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_013BxYz6WPoQw6obcp6eJrxS)_