### PR TITLE
fix: keep bundle queries under D1's 100-parameter cap

### DIFF
--- a/src/__tests__/repository/bundle-repository.test.ts
+++ b/src/__tests__/repository/bundle-repository.test.ts
@@ -247,6 +247,21 @@ describe("BundleRepository.listLinks", () => {
     const bundle = await BundleRepository.create(env.DB, { name: "OSS", createdBy: "a@b" });
     expect(await BundleRepository.listLinks(env.DB, bundle.id)).toEqual([]);
   });
+
+  // D1 caps a prepared statement at 100 bound parameters, so the slug loader
+  // cannot bind one parameter per member link.
+  it("returns member links past the D1 bind cap", async () => {
+    const bundle = await BundleRepository.create(env.DB, { name: "Wide", createdBy: "a@b" });
+    const count = 105;
+    for (let i = 0; i < count; i++) {
+      const link = await LinkRepository.create(env.DB, { url: `https://a.com/${i}`, slug: `wide-${i}`, createdBy: "a@b" });
+      await BundleRepository.addLink(env.DB, bundle.id, link.id);
+    }
+
+    const links = await BundleRepository.listLinks(env.DB, bundle.id);
+    expect(links).toHaveLength(count);
+    expect(links.every((l) => l.slugs.length === 1)).toBe(true);
+  });
 });
 
 describe("BundleRepository.listBundlesForLink", () => {

--- a/src/__tests__/repository/click-repository.test.ts
+++ b/src/__tests__/repository/click-repository.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { env } from "cloudflare:test";
 import { applyMigrations, resetData } from "../setup";
 import { BundleRepository, ClickRepository, LinkRepository, SlugRepository } from "../../db";
+import { computeDelta } from "../../services/trends";
 
 beforeAll(applyMigrations);
 beforeEach(resetData);
@@ -552,6 +553,83 @@ describe("ClickRepository.getBundleStats", () => {
     expect(stats.clicked_links).toBe(1);
     // link2 appears with 0 clicks
     expect(stats.per_link.find((p) => p.link_id === link2.id)?.click_count).toBe(0);
+  });
+});
+
+// D1 caps a prepared statement at 100 bound parameters. Scoping bundle
+// analytics by binding one parameter per member slug blew that cap on real
+// bundles (bundle 3 in production carries 99 slugs), so every query here uses
+// a slug count past the limit.
+describe("ClickRepository bundle analytics past the D1 bind cap", () => {
+  const LINKS = 51; // 2 slugs per link => 102 slugs, past D1's 100-parameter cap
+
+  async function bigBundle() {
+    const bundle = await BundleRepository.create(env.DB, { name: "Wide", createdBy: "a@b" });
+    const linkIds: number[] = [];
+    const slugs: string[] = [];
+    for (let i = 0; i < LINKS; i++) {
+      const link = await LinkRepository.create(env.DB, { url: `https://a.com/${i}`, slug: `wide-${i}`, createdBy: "a@b" });
+      await SlugRepository.addCustom(env.DB, link.id, `wide-${i}-alt`);
+      await BundleRepository.addLink(env.DB, bundle.id, link.id);
+      linkIds.push(link.id);
+      slugs.push(`wide-${i}`, `wide-${i}-alt`);
+    }
+    return { bundle, linkIds, slugs };
+  }
+
+  it("getBundleStats aggregates a bundle whose slug count exceeds the cap", async () => {
+    const { bundle, linkIds, slugs } = await bigBundle();
+    expect(slugs.length).toBeGreaterThan(100);
+
+    const now = Math.floor(Date.now() / 1000);
+    // Current 30d window: one click on the first slug of every link, plus an
+    // extra on the last link's alternate slug.
+    for (const slug of slugs.filter((_, i) => i % 2 === 0)) {
+      await recordClick(slug, now - 3600, { country: "US" });
+    }
+    await recordClick(slugs[slugs.length - 1], now - 3600, { country: "ID" });
+    // Previous 30d window: two clicks, so the delta is computable.
+    await recordClick(slugs[0], now - 40 * 86400);
+    await recordClick(slugs[1], now - 40 * 86400);
+
+    const stats = (await ClickRepository.getBundleStats(env.DB, bundle.id, "30d", now))!;
+    expect(stats.link_count).toBe(LINKS);
+    expect(stats.total_clicks).toBe(LINKS + 1);
+    expect(stats.clicked_links).toBe(LINKS);
+    expect(stats.countries_reached).toBe(2);
+    expect(stats.per_link).toHaveLength(LINKS);
+    expect(stats.per_link.find((p) => p.link_id === linkIds[LINKS - 1])?.click_count).toBe(2);
+    expect(stats.delta_pct).toBe(computeDelta(LINKS + 1, 2));
+    expect(stats.timeline.summary.last_24h).toBe(LINKS + 1);
+    expect(stats.timeline.summary.last_90d).toBe(LINKS + 3);
+    expect(stats.timeline.buckets.some((b) => b.count > 0)).toBe(true);
+  });
+
+  it("getBundleStats aggregates an over-cap bundle over the all range", async () => {
+    const { bundle, slugs } = await bigBundle();
+    const now = Math.floor(Date.now() / 1000);
+    await recordClick(slugs[0], now - 400 * 86400, { country: "US" });
+    await recordClick(slugs[1], now - 60, { country: "US" });
+
+    const stats = (await ClickRepository.getBundleStats(env.DB, bundle.id, "all", now))!;
+    expect(stats.total_clicks).toBe(2);
+    expect(stats.delta_pct).toBeUndefined();
+    expect(stats.timeline.buckets.length).toBeGreaterThan(0);
+  });
+
+  it("getBundleBreakdownPage pages an over-cap bundle", async () => {
+    const { bundle, slugs } = await bigBundle();
+    const now = Math.floor(Date.now() / 1000);
+    await recordClick(slugs[0], now - 60, { country: "US" });
+    await recordClick(slugs[1], now - 60, { country: "US" });
+    await recordClick(slugs[2], now - 60, { country: "ID" });
+
+    const page = await ClickRepository.getBundleBreakdownPage(env.DB, bundle.id, "countries", "30d", 0, 10, now);
+    expect(page.total).toBe(2);
+    expect(page.items).toEqual([
+      { name: "US", count: 2 },
+      { name: "ID", count: 1 },
+    ]);
   });
 });
 

--- a/src/db/bundle-repository.ts
+++ b/src/db/bundle-repository.ts
@@ -176,13 +176,16 @@ export class BundleRepository {
     const links = linkRows.results ?? [];
     if (links.length === 0) return [];
 
-    const linkIds = links.map((l) => l.id);
-    const placeholders = linkIds.map(() => "?").join(",");
+    // Resolve membership inside SQLite rather than binding one parameter per
+    // member link: D1 caps a statement at 100 bound parameters, and wide
+    // bundles pass that.
     const slugRows = await db
       .prepare(
-        `SELECT ${slugSelect(opts)} FROM slugs s WHERE link_id IN (${placeholders}) ORDER BY is_custom ASC, created_at ASC`,
+        `SELECT ${slugSelect(opts)} FROM slugs s
+         WHERE link_id IN (SELECT link_id FROM bundle_links WHERE bundle_id = ?)
+         ORDER BY is_custom ASC, created_at ASC`,
       )
-      .bind(...linkIds)
+      .bind(bundleId)
       .all<Slug>();
 
     const slugsByLink = new Map<number, Slug[]>();

--- a/src/db/click-repository.ts
+++ b/src/db/click-repository.ts
@@ -54,6 +54,23 @@ async function runBreakdownPage(
   return { items: rows.results ?? [], total: totalRow?.cnt ?? 0 };
 }
 
+/**
+ * WHERE fragment matching every click on a slug that belongs to a bundle,
+ * costing exactly one bound parameter (the bundle id).
+ *
+ * D1 caps a prepared statement at 100 bound parameters. Expanding the member
+ * slugs into an `IN (?,?,...)` list blew that cap once a bundle grew past ~99
+ * slugs and failed the whole analytics page with SQLITE_ERROR. Resolving the
+ * membership inside SQLite keeps the bind count flat at any bundle size, and
+ * the planner still drives the lookup off idx_clicks_slug.
+ *
+ * Pass `column` when the clicks table is joined under an alias. The subquery
+ * aliases (bl_/s_) stay distinct from the aliases callers use outside it.
+ */
+function bundleSlugScope(column = "slug"): string {
+  return `${column} IN (SELECT s_.slug FROM bundle_links bl_ JOIN slugs s_ ON s_.link_id = bl_.link_id WHERE bl_.bundle_id = ?)`;
+}
+
 export type { ClickFilters } from "./filters";
 
 export class ClickRepository {
@@ -506,20 +523,8 @@ export class ClickRepository {
     now?: number,
     filters?: ClickFilters,
   ): Promise<BreakdownPage> {
-    const slugRows = await db
-      .prepare(
-        `SELECT s.slug as slug FROM bundle_links bl
-         JOIN slugs s ON s.link_id = bl.link_id
-         WHERE bl.bundle_id = ?`,
-      )
-      .bind(bundleId)
-      .all<{ slug: string }>();
-    const slugs = (slugRows.results ?? []).map((r) => r.slug);
-    if (slugs.length === 0) return { items: [], total: 0 };
-
-    const placeholders = slugs.map(() => "?").join(",");
-    let where = `slug IN (${placeholders})`;
-    const binds: (string | number)[] = [...slugs];
+    let where = bundleSlugScope();
+    const binds: (string | number)[] = [bundleId];
     if (range !== "all") {
       const ts = now ?? Math.floor(Date.now() / 1000);
       where += " AND clicked_at >= ?";
@@ -1071,9 +1076,8 @@ export class ClickRepository {
 
     if (slugs.length === 0) return empty;
 
-    const placeholders = slugs.map(() => "?").join(",");
-    let where = `slug IN (${placeholders})`;
-    const binds: (string | number)[] = [...slugs];
+    let where = bundleSlugScope();
+    const binds: (string | number)[] = [bundleId];
     if (range !== "all") {
       const sinceTs = ts - RANGE_SECONDS[range];
       where += " AND clicked_at >= ?";
@@ -1111,7 +1115,7 @@ export class ClickRepository {
       db.prepare(`SELECT link_mode as name, COUNT(*) as count FROM clicks WHERE ${where} GROUP BY link_mode ORDER BY count DESC`).bind(...binds).all<{ name: string; count: number }>(),
       (() => {
         const filterFragC = clickFilterSql(filters, "c");
-        let perLinkWhere = `c.slug IN (${placeholders})`;
+        let perLinkWhere = bundleSlugScope("c.slug");
         if (range !== "all") perLinkWhere += " AND c.clicked_at >= ?";
         perLinkWhere += filterFragC;
         return db.prepare(
@@ -1122,8 +1126,8 @@ export class ClickRepository {
            ORDER BY cnt DESC`,
         ).bind(...binds).all<{ link_id: number; cnt: number }>();
       })(),
-      this.getBundleTimeline(db, slugs, range, ts, filters),
-      this.getBundlePeriodClicks(db, slugs, range, ts, filters),
+      this.getBundleTimeline(db, bundleId, range, ts, filters),
+      this.getBundlePeriodClicks(db, bundleId, range, ts, filters),
       db.prepare(`SELECT COUNT(DISTINCT referrer) as cnt FROM clicks WHERE ${where} AND referrer IS NOT NULL AND referrer NOT LIKE 'android-app://%' AND referrer NOT LIKE 'ios-app://%'`).bind(...binds).first<{ cnt: number }>(),
       db.prepare(`SELECT COUNT(DISTINCT referrer_host) as cnt FROM clicks WHERE ${where} AND referrer_host IS NOT NULL`).bind(...binds).first<{ cnt: number }>(),
       db.prepare(`SELECT COUNT(DISTINCT os) as cnt FROM clicks WHERE ${where} AND os IS NOT NULL`).bind(...binds).first<{ cnt: number }>(),
@@ -1136,7 +1140,7 @@ export class ClickRepository {
     // Attach per-link deltas in two more grouped queries (scoped to bundle slugs).
     const perLinkDeltas = range === "all"
       ? new Map<number, number | undefined>()
-      : await this.getBundlePerLinkDeltas(db, slugs, range, ts, filters);
+      : await this.getBundlePerLinkDeltas(db, bundleId, range, ts, filters);
 
     const perLink: BundleStatsPerLink[] = [];
     for (const row of perLinkRows.results ?? []) {
@@ -1207,23 +1211,18 @@ export class ClickRepository {
     };
   }
 
-  /** Timeline (range-bucketed) scoped to an explicit slug list. */
+  /**
+   * Timeline (range-bucketed) scoped to a bundle's member slugs. Callers reach
+   * this only after confirming the bundle has members.
+   */
   private static async getBundleTimeline(
     db: D1Database,
-    slugs: string[],
+    bundleId: number,
     range: TimelineRange,
     ts: number,
     filters?: ClickFilters,
   ): Promise<TimelineData> {
-    const empty: TimelineData = {
-      range,
-      buckets: [],
-      summary: { last_24h: 0, last_7d: 0, last_30d: 0, last_90d: 0, last_1y: 0 },
-    };
-    if (slugs.length === 0) return empty;
-
-    const placeholders = slugs.map(() => "?").join(",");
-    const where = `slug IN (${placeholders})${clickFilterSql(filters)}`;
+    const where = `${bundleSlugScope()}${clickFilterSql(filters)}`;
 
     const t24h = ts - 86400;
     const t7d = ts - 7 * 86400;
@@ -1231,11 +1230,11 @@ export class ClickRepository {
     const t90d = ts - 90 * 86400;
     const t1y = ts - 365 * 86400;
     const [last24h, last7d, last30d, last90d, last1y] = await Promise.all([
-      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(...slugs, t24h).first<{ cnt: number }>(),
-      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(...slugs, t7d).first<{ cnt: number }>(),
-      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(...slugs, t30d).first<{ cnt: number }>(),
-      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(...slugs, t90d).first<{ cnt: number }>(),
-      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(...slugs, t1y).first<{ cnt: number }>(),
+      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(bundleId, t24h).first<{ cnt: number }>(),
+      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(bundleId, t7d).first<{ cnt: number }>(),
+      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(bundleId, t30d).first<{ cnt: number }>(),
+      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(bundleId, t90d).first<{ cnt: number }>(),
+      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(bundleId, t1y).first<{ cnt: number }>(),
     ]);
 
     const summary = {
@@ -1275,7 +1274,7 @@ export class ClickRepository {
       case "all": {
         const earliestRow = await db
           .prepare(`SELECT MIN(clicked_at) as t FROM clicks WHERE ${where}`)
-          .bind(...slugs)
+          .bind(bundleId)
           .first<{ t: number | null }>();
         allEarliest = earliestRow?.t ?? ts;
         const spanDays = Math.max(1, Math.floor((ts - allEarliest) / 86400));
@@ -1295,7 +1294,7 @@ export class ClickRepository {
     }
 
     const timeFilter = sinceTs !== null ? " AND clicked_at >= ?" : "";
-    const binds = sinceTs !== null ? [...slugs, sinceTs] : [...slugs];
+    const binds = sinceTs !== null ? [bundleId, sinceTs] : [bundleId];
 
     const rows = await db
       .prepare(
@@ -1314,22 +1313,20 @@ export class ClickRepository {
     return { range, buckets, summary };
   }
 
-  /** Current vs previous period click counts scoped to an explicit slug list. */
+  /** Current vs previous period click counts scoped to a bundle's member slugs. */
   private static async getBundlePeriodClicks(
     db: D1Database,
-    slugs: string[],
+    bundleId: number,
     range: TimelineRange,
     ts: number,
     filters?: ClickFilters,
   ): Promise<{ current: number; previous: number }> {
-    if (slugs.length === 0) return { current: 0, previous: 0 };
-    const placeholders = slugs.map(() => "?").join(",");
-    const where = `slug IN (${placeholders})${clickFilterSql(filters)}`;
+    const where = `${bundleSlugScope()}${clickFilterSql(filters)}`;
 
     if (range === "all") {
       const row = await db
         .prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where}`)
-        .bind(...slugs)
+        .bind(bundleId)
         .first<{ cnt: number }>();
       return { current: row?.cnt ?? 0, previous: 0 };
     }
@@ -1339,23 +1336,23 @@ export class ClickRepository {
     const prevStart = ts - 2 * span;
 
     const [cur, prev] = await Promise.all([
-      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(...slugs, currStart).first<{ cnt: number }>(),
-      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ? AND clicked_at < ?`).bind(...slugs, prevStart, currStart).first<{ cnt: number }>(),
+      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ?`).bind(bundleId, currStart).first<{ cnt: number }>(),
+      db.prepare(`SELECT COUNT(*) as cnt FROM clicks WHERE ${where} AND clicked_at >= ? AND clicked_at < ?`).bind(bundleId, prevStart, currStart).first<{ cnt: number }>(),
     ]);
     return { current: cur?.cnt ?? 0, previous: prev?.cnt ?? 0 };
   }
 
   private static async getBundlePerLinkDeltas(
     db: D1Database,
-    slugs: string[],
+    bundleId: number,
     range: TimelineRange,
     ts: number,
     filters?: ClickFilters,
   ): Promise<Map<number, number | undefined>> {
     const out = new Map<number, number | undefined>();
-    if (slugs.length === 0 || range === "all") return out;
+    if (range === "all") return out;
 
-    const placeholders = slugs.map(() => "?").join(",");
+    const scope = bundleSlugScope("c.slug");
     const filterFrag = clickFilterSql(filters, "c");
     const span = RANGE_SECONDS[range];
     const currStart = ts - span;
@@ -1366,19 +1363,19 @@ export class ClickRepository {
         .prepare(
           `SELECT s.link_id as link_id, COUNT(*) as cnt
            FROM clicks c JOIN slugs s ON s.slug = c.slug
-           WHERE c.slug IN (${placeholders}) AND c.clicked_at >= ?${filterFrag}
+           WHERE ${scope} AND c.clicked_at >= ?${filterFrag}
            GROUP BY s.link_id`,
         )
-        .bind(...slugs, currStart)
+        .bind(bundleId, currStart)
         .all<{ link_id: number; cnt: number }>(),
       db
         .prepare(
           `SELECT s.link_id as link_id, COUNT(*) as cnt
            FROM clicks c JOIN slugs s ON s.slug = c.slug
-           WHERE c.slug IN (${placeholders}) AND c.clicked_at >= ? AND c.clicked_at < ?${filterFrag}
+           WHERE ${scope} AND c.clicked_at >= ? AND c.clicked_at < ?${filterFrag}
            GROUP BY s.link_id`,
         )
-        .bind(...slugs, prevStart, currStart)
+        .bind(bundleId, prevStart, currStart)
         .all<{ link_id: number; cnt: number }>(),
     ]);
 


### PR DESCRIPTION
## Problem

`/_/admin/bundles/3` returned 500 with `too many SQL variables: SQLITE_ERROR`.

D1 caps a prepared statement at 100 bound parameters. `getBundleStats` expanded every member slug into `slug IN (?,?,…)`, so the failing query was:

```
slug IN (99 placeholders) AND is_bot = 0 AND is_self_referrer = 0 AND clicked_at >= ? AND clicked_at < ?
```

99 slugs + 2 timestamps = 101 binds. Bundle 3 carries 99 slugs across 54 links. Queries binding a single timestamp landed on exactly 100 and passed, which is why only the previous-period counts and per-link deltas blew up.

## Fix

Bundle-scoped click queries resolve membership inside SQLite instead of binding one parameter per slug:

```sql
slug IN (SELECT s_.slug FROM bundle_links bl_ JOIN slugs s_ ON s_.link_id = bl_.link_id WHERE bl_.bundle_id = ?)
```

The bind count stays at one whatever the bundle size. `EXPLAIN QUERY PLAN` against production keeps the same `SEARCH clicks USING INDEX idx_clicks_slug` lookup, and the previously failing count returns 2657 reading 11771 rows against 11565 for the literal list. `getBundleBreakdownPage` drops its slug-resolution round trip too.

Second commit covers the same defect in `BundleRepository.listLinks`, which bound one parameter per member link. Bundle 3 sits at 54 links and keeps growing, so that path would have broken the same page at 100.

## Tests

Four new tests build bundles past the cap (102 slugs, 105 links). All four fail on `main` with the production error, since the local D1 in vitest-pool-workers enforces the same limit.

- `getBundleStats` over a ranged window: totals, per-link rows, delta, timeline summary
- `getBundleStats` over the `all` range
- `getBundleBreakdownPage` paging
- `BundleRepository.listLinks`

Full suite: 1082 tests across 73 files pass. `tsc --noEmit` clean.

## Not covered

Two same-class sites stay as they are, neither reachable today: per-link analytics bind one parameter per slug of a single link (production max is 8), and the bundles listing binds one per bundle id (3 exist).

Deploying this needs an app version bump, which also stales the three SDK spec hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)