### PR TITLE
Release app 0.37.1, npm 1.1.3, python 1.1.2, pub 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.37.1 (2026-08-10)
+
+Defect-fix release (PRs #36, #37, and the weekly review batch). No new endpoints or schema changes.
+
+- **Stored XSS closed in the bundle icon picker.** The icon name was interpolated into an inline `onclick` JS-string argument. A bundle icon is a free-text field with no charset restriction, so a quote in the value broke out of the string literal into executable script. The name now rides on `data-icon` and the handler reads `this.dataset.icon`. `esc()` also escapes the double-quote character, which `textContent`/`innerHTML` round-tripping leaves untouched, so a quote in any value placed inside a double-quoted attribute can no longer close it early.
+- **Bundle analytics no longer fails past 99 member slugs.** D1 caps a prepared statement at 100 bound parameters. Expanding a bundle's member slugs into an `IN (?,?,...)` list crossed that cap on wide bundles and failed the whole analytics page with `SQLITE_ERROR`. Every bundle-scoped click query now resolves membership inside SQLite from the bundle id, holding the bind count at one regardless of bundle size. The planner still drives the lookup off `idx_clicks_slug`.
+- **Bundle member slugs load on one bound parameter.** `BundleRepository` bound one parameter per member link to read their slugs, hitting the same D1 cap from the other direction. The membership subquery replaces the id list.
+- **Admin toasts survive a response carrying no JSON body.** Failure paths called `res.json()` and rendered `data.error`, so a 502 from an edge proxy or any non-JSON error body rejected the promise and left the button silent with nothing shown to the user. Every such path now falls back to its translated default message.
+- **Deleting a custom slug reports the deletion.** The success toast read "Custom slug added". Its failure toast, and those for set-primary, disable, and enable, showed a bare untranslated "Error".
+- **Custom slugs enforce a maximum length.** `validateCustomSlug` checked the lower bound and the charset but never the upper, so a caller could store a slug longer than `MAX_SLUG_LENGTH` through the API while the random generator stayed within it.
+- **A trailing `?` inside a fragment survives normalization.** The trailing-`?` strip ran unconditionally, so `https://example.com/#section?` lost a character of fragment content. A `?` at the end only denotes an empty query string when no `#` has opened a fragment ahead of it.
+- **`fetchPageTitle` drains non-HTML bodies.** The early return on a non-HTML content type abandoned the response stream. Most destination URLs are not HTML (APIs, PDFs, images), and this runs on every link creation, so the leak sat on the common path.
+- **Remaining hardcoded admin strings route through `t()`.** The add-slug modal's field label and four slug-action error messages were inline English.
+- OpenAPI paths and schemas are unchanged from 0.37.0; only `info.version` changes. The bump refreshes the recorded spec hash in all three SDKs. TypeScript ships 1.1.3, Python 1.1.2, and Dart 2.1.2 alongside it. Full suite: 76 files, 1128 tests.
+
 ## 0.37.0 (2026-08-05)
 
 Feature and defect release (PRs #34, #35). Adds per-point dates to the clicks-over-time chart and closes three defects from the weekly review.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shrtnr",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "A free, open-source, self-hosted URL shortener built on Cloudflare Workers + D1",
   "license": "Apache-2.0",
   "engines": {

--- a/sdk/dart/CHANGELOG.md
+++ b/sdk/dart/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.1.2 (2026-08-10)
+
+Error-handling fixes. No public surface changes.
+
+- A connection reset partway through a response body throws `ShrtnrError` with status 0. `send()` yields only headers and status; `http.Response.fromStream` reads the body afterward, so a mid-transfer drop surfaced as a raw stream error at that second call and escaped the documented "network failures throw `ShrtnrError(status: 0)`" guarantee. Both `requestJson` and `requestText` wrap the read.
+- An empty body served with a non-204 2xx throws `ShrtnrError(statusCode, 'Empty response body')`, joining the adjacent guard that already rejects a non-JSON 2xx body. Nothing on the wire separates "no content by design" from a proxy that stripped the body off a 200, and every resource method follows the call with `json!`, so the truncated case reported "Null check operator used on a null value" and skipped `on ShrtnrError` handlers. A 204 still returns null. The Python SDK carries the same fix in 1.1.2.
+- Records the spec hash for app 0.37.1. Paths and schemas are unchanged; only `info.version` moved.
+
 ## 2.1.1 (2026-07-28)
 
 Error-handling and deserialization fixes. No public surface changes.

--- a/sdk/dart/lib/src/base_client.dart
+++ b/sdk/dart/lib/src/base_client.dart
@@ -80,7 +80,15 @@ class ShrtnrBaseClient {
     }
 
     if (response.statusCode >= 200 && response.statusCode < 300) {
-      if (response.statusCode == 204 || response.body.isEmpty) return null;
+      if (response.statusCode == 204) return null;
+      // An empty body on a non-204 2xx is the same "truncated body served
+      // with a 200" case the jsonDecode branch below covers (a CDN or proxy
+      // that strips the body off some 2xx responses). Returning null only
+      // defers the failure to the caller's `json!`, which reports it as a
+      // null-check error instead of the documented ShrtnrError.
+      if (response.body.isEmpty) {
+        throw ShrtnrError(response.statusCode, 'Empty response body');
+      }
       try {
         return jsonDecode(response.body);
       } catch (e) {

--- a/sdk/dart/pubspec.yaml
+++ b/sdk/dart/pubspec.yaml
@@ -1,10 +1,10 @@
 name: shrtnr
 description: Dart client for the shrtnr URL shortener API. Create short links, manage custom slugs, and read click analytics.
-version: 2.1.1
+version: 2.1.2
 homepage: https://oddb.it/shrtnr-website-pub
 repository: https://github.com/oddbit/shrtnr
 issue_tracker: https://github.com/oddbit/shrtnr/issues
-# x-spec-hash: sha256:58c26e1197a2f362aed66e93128cf92ca3921355a9e5b5ff0eb8cdfc70958c9b
+# x-spec-hash: sha256:d4cf1923d90f1abe638c5974463df6656dac6894b6980ba1e9d4858494deb956
 # Stored as a comment rather than a top-level key to avoid a pana score deduction for unknown manifest fields.
 
 topics:

--- a/sdk/dart/test/client_test.dart
+++ b/sdk/dart/test/client_test.dart
@@ -285,6 +285,23 @@ void main() {
         expect(e.status, 0);
       }
     });
+
+    test('throws ShrtnrError on an empty body served with a non-204 2xx',
+        () async {
+      // A proxy that strips the body off a 200 leaves nothing to build a
+      // model from, so returning null here only defers the failure to the
+      // resource method's `json!` and reports it as a null-check error
+      // rather than the documented ShrtnrError. Python 1.1.2 raises on the
+      // same case.
+      final m = _mock(status: 200);
+      try {
+        await m.client.links.list();
+        fail('expected ShrtnrError');
+      } on ShrtnrError catch (e) {
+        expect(e.status, 200);
+        expect(e.serverMessage, contains('Empty response body'));
+      }
+    });
   });
 
   // ---- 3. links.get ----

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the SDK are documented in this file.
 
+## 1.1.2 (2026-08-10)
+
+Error-handling fix. No public surface changes.
+
+- An empty body served with a non-204 2xx raises `ShrtnrError(status, "Empty response body")`. This is the same "truncated body served with a 200" case the invalid-JSON guard covers, for instance a proxy that strips the body off some 2xx responses. Returning `None` only deferred the failure to the resource method's `SomeModel.from_dict(...)`, which reported it as a bare `AttributeError` and slipped past `except ShrtnrError` handling. A 204 still returns `None`. The Dart SDK carries the same fix in 2.1.2; TypeScript reaches the same outcome through its JSON-parse guard.
+- Documentation: the `Key types` list names the types added since it was written (`BundleTopLink`, `DateCount`, `SlugCount`, `BreakdownDimension`, `BreakdownPage`).
+- Records the spec hash for app 0.37.1. Paths and schemas are unchanged; only `info.version` moved.
+
 ## 1.1.1 (2026-07-28)
 
 - A 2xx response whose body is not valid JSON now raises `ShrtnrError(status)`. Previously `response.json()` raised a bare `JSONDecodeError`, so an HTML error page or a truncated body served with a 200 escaped the SDK's error type. The TypeScript and Dart SDKs carry the same fix in 1.1.1 and 2.1.1.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "shrtnr"
-version = "1.1.1"
+version = "1.1.2"
 description = "SDK for the shrtnr URL shortener API"
 readme = "README.md"
 license = "Apache-2.0"
@@ -98,7 +98,7 @@ warn_redundant_casts = true
 warn_unreachable = true
 
 [tool.shrtnr]
-spec_hash = "sha256:58c26e1197a2f362aed66e93128cf92ca3921355a9e5b5ff0eb8cdfc70958c9b"
+spec_hash = "sha256:d4cf1923d90f1abe638c5974463df6656dac6894b6980ba1e9d4858494deb956"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/sdk/typescript/CHANGELOG.md
+++ b/sdk/typescript/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the SDK are documented in this file.
 
+## 1.1.3 (2026-08-10)
+
+Error-handling fixes. No public surface changes.
+
+- A caller-supplied `fetch` binds to `globalThis`, matching the treatment the default already got in 1.1.1. Only the fallback branch was ever bound, so `fetch: window.fetch` (the README's own custom-fetch example) was invoked with the `HttpClient` instance as its receiver and failed the brand check browsers perform on `fetch`, throwing `Illegal invocation`.
+- A connection reset partway through a response body raises `ShrtnrError` with status 0 rather than escaping the SDK's error type. `fetch` settles once headers arrive, so the body read is a second point of failure that neither path accounted for: `qr()` returned `res.text()` unwrapped and leaked a raw `TypeError`, and JSON responses reported the response status, labelling a transport failure as `ShrtnrError(200, "Invalid JSON response: ...")`. Reading the body and parsing it are now separate steps, so a failed read carries status 0 and only a body that arrived intact but is not JSON keeps the response status.
+- Documentation: the `Key types` list names the types added since it was written (`BundleTopLink`, `DateCount`, `SlugCount`, `DeletedResult`, `AddedResult`, `RemovedResult`, `BreakdownDimension`, `BreakdownPage`).
+- Records the spec hash for app 0.37.1. Paths and schemas are unchanged; only `info.version` moved.
+
 ## 1.1.2 (2026-08-05)
 
 Serialization fix. No public surface changes.

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oddbit/shrtnr",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "SDK for the shrtnr URL shortener API",
   "homepage": "https://oddb.it/shrtnr-website-npm",
   "license": "Apache-2.0",
@@ -51,5 +51,5 @@
     "click-analytics",
     "custom-slug"
   ],
-  "x-spec-hash": "sha256:58c26e1197a2f362aed66e93128cf92ca3921355a9e5b5ff0eb8cdfc70958c9b"
+  "x-spec-hash": "sha256:d4cf1923d90f1abe638c5974463df6656dac6894b6980ba1e9d4858494deb956"
 }

--- a/sdk/typescript/src/internal/http.ts
+++ b/sdk/typescript/src/internal/http.ts
@@ -79,9 +79,16 @@ export class HttpClient {
 
     if (res.status === 204) return undefined as T;
 
+    // fetch settles once headers arrive; the body streams afterward, so a
+    // connection reset mid-transfer fails here rather than at the call
+    // above. Read and parse in separate steps to keep the two apart: a
+    // transport failure reports status 0 like every other network error,
+    // and only a body that arrived intact but isn't JSON carries the
+    // response status.
+    const text = await this.readBody(res);
     let json: unknown;
     try {
-      json = await res.json();
+      json = JSON.parse(text);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       throw new ShrtnrError(res.status, `Invalid JSON response: ${msg}`);
@@ -118,7 +125,16 @@ export class HttpClient {
       throw new ShrtnrError(res.status, serverMessage);
     }
 
-    return res.text();
+    return this.readBody(res);
+  }
+
+  private async readBody(res: Response): Promise<string> {
+    try {
+      return await res.text();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new ShrtnrError(0, msg);
+    }
   }
 
   private buildUrl(path: string, query?: Record<string, string | undefined>): string {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -25,6 +25,17 @@ function client(): ShrtnrClient {
   return new ShrtnrClient({ baseUrl: BASE, apiKey: API_KEY, fetch: fetchSpy });
 }
 
+// Yields headers and a first chunk, then errors while the body is still
+// streaming: the failure mode a rejected fetch() promise cannot reproduce.
+function erroringBody(): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("["));
+      controller.error(new TypeError("connection reset"));
+    },
+  });
+}
+
 function lastCall(): { url: string; init: RequestInit } {
   const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
   return { url, init };
@@ -200,6 +211,54 @@ describe("Error handling", () => {
       await expect(client().links.list()).resolves.toEqual([]);
     } finally {
       globalThis.fetch = realFetch;
+    }
+  });
+
+  it("throws ShrtnrError on an empty body served with a non-204 2xx", async () => {
+    // A proxy that strips the body off a 200 leaves nothing for a resource
+    // method to build a model from. Python raises here and Dart 2.1.2 does
+    // too; TypeScript reaches the same outcome through its JSON-parse guard.
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 200 }));
+    try {
+      await client().links.get(1);
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ShrtnrError);
+    }
+  });
+
+  it("reports status 0 when the connection drops mid-body on a JSON response", async () => {
+    // fetch resolves once headers land; the body streams afterward. Reading
+    // it through res.json() reported the response status, so a connection
+    // reset partway through a 200 surfaced as ShrtnrError(200) and read as a
+    // server-side problem. The body read now carries status 0 like every
+    // other transport failure, matching Dart and Python.
+    fetchSpy.mockResolvedValueOnce(new Response(erroringBody(), { status: 200 }));
+    try {
+      await client().links.list();
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ShrtnrError);
+      expect((e as ShrtnrError).status).toBe(0);
+    }
+  });
+
+  it("wraps a mid-body stream failure on a text response in ShrtnrError", async () => {
+    // requestText handed back res.text() unwrapped, so a reset partway
+    // through a QR download escaped as a raw TypeError past the documented
+    // "network failures throw ShrtnrError with status 0" contract.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(erroringBody(), {
+        status: 200,
+        headers: { "Content-Type": "image/svg+xml" },
+      }),
+    );
+    try {
+      await client().links.qr(5);
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ShrtnrError);
+      expect((e as ShrtnrError).status).toBe(0);
     }
   });
 });


### PR DESCRIPTION
Cuts all four release tracks. Two SDK parity fixes go in ahead of the version bumps.

## Tracks

| Target | Version | Contents |
|---|---|---|
| Cloudflare Workers app | 0.37.0 → 0.37.1 | 9 defect fixes from the 17 commits since `app-v0.37.0` |
| npm `@oddbit/shrtnr` | 1.1.2 → 1.1.3 | fetch binding, body-read wrapping |
| PyPI `shrtnr` | 1.1.1 → 1.1.2 | empty-body 2xx raises |
| pub.dev `shrtnr` | 2.1.1 → 2.1.2 | body-read wrapping, empty-body 2xx raises |

## Parity fixes

Three SDK error-handling fixes reached `main` in one SDK each. Two of them applied elsewhere and had not been carried over, so the parity rule in CLAUDE.md was not satisfied:

- **Dart** returned `null` on an empty-body non-204 2xx while Python had started raising. Every resource method follows the call with `json!`, so a body-stripping proxy produced "Null check operator used on a null value" rather than `ShrtnrError`, skipping `on ShrtnrError` handlers.
- **TypeScript** `requestText` returned `res.text()` unwrapped, so a reset partway through a QR download leaked a raw `TypeError` past the documented status-0 contract. The JSON path also conflated the two failures and reported `ShrtnrError(200, "Invalid JSON response")` for a transport fault. Reading and parsing are now separate steps: a failed read carries status 0, and only a body that arrived intact but is not JSON keeps the response status.

The TypeScript `fetch`-binding fix has no analogue in the other two (neither takes a fetch callable). Python needs nothing for the body read: httpx buffers inside the request call the resource methods already wrap in `except httpx.RequestError`.

Tests came first for both. Each fails before its fix and passes after.

## Spec hash

`d4cf1923d90f1abe638c5974463df6656dac6894b6980ba1e9d4858494deb956`, recorded in all three manifests in the app release commit so the `sdk-spec-drift` gate stays green at every commit.

No SDK surface change. `src/api/` and `src/mcp/` are untouched since `app-v0.37.0`, and diffing the emitted spec against 0.37.0 with `info.version` removed comes back identical. The hash moves for the version string alone, which is what justifies a hash-only bump with no regeneration.

MCP tools gain no new surface, but the bundle-analytics bind-cap fix changes their behavior in practice: the analytics tools read through `ClickRepository`, so bundles with more than ~99 slugs previously failed the whole call with `SQLITE_ERROR` and now return data.

## Verification

Run locally on every track:

- App: 76 files, 1128 tests pass
- npm: 77 tests, `tsc --noEmit` clean, build succeeds
- PyPI: 95 tests, `mypy --strict` clean, `ruff` clean
- pub.dev: 92 tests, `dart analyze` clean (the `e2e_test.dart` env-var guard fails locally without live credentials, as expected)
- Replicated CI's `sdk-spec-drift` gate: all three recorded hashes match the computed one

## Publishing

Merging fires the app deploy, the npm publish, and the PyPI publish. pub.dev is tag-driven: `pub-v2.1.2` exists locally and is unpushed. Per `docs/release-automation.md` the tag has to come from a user identity, so push it after the merge:

```bash
git push origin pub-v2.1.2
```

Merge with a merge commit, not a squash, or that tag ends up pointing at a commit that is not on `main`.