### PR TITLE
Weekly defect review: 5 fixes across admin UI, API, TS SDK, and browser extension

### DIFF
--- a/browser-extensions/src/components/ConfigForm.tsx
+++ b/browser-extensions/src/components/ConfigForm.tsx
@@ -156,9 +156,10 @@ export function ConfigForm({ t, initial, onSaved, showCancel, onCancel }: Props)
       await setConfig({ baseUrl: baseUrl.trim(), apiKey: trimmedKey });
       setSaveState({ kind: "idle" });
       onSaved({ baseUrl: normalizedOrigin, apiKey: trimmedKey });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Save failed";
-      setSaveState({ kind: "error", messageKey: "error.validation", params: { message } });
+    } catch {
+      // chrome.storage rejections carry English-only browser strings
+      // (quota, write-rate). Report a localized message instead.
+      setSaveState({ kind: "error", messageKey: "error.saveFailed" });
     }
   }
 

--- a/browser-extensions/src/components/ConfigForm.tsx
+++ b/browser-extensions/src/components/ConfigForm.tsx
@@ -82,11 +82,7 @@ export function ConfigForm({ t, initial, onSaved, showCancel, onCancel }: Props)
     try {
       origin = new URL(baseUrl.trim()).origin;
     } catch {
-      setTestState({
-        kind: "error",
-        messageKey: "error.validation",
-        params: { message: "Invalid URL" },
-      });
+      setTestState({ kind: "error", messageKey: "error.invalidUrl" });
       return;
     }
 
@@ -135,11 +131,7 @@ export function ConfigForm({ t, initial, onSaved, showCancel, onCancel }: Props)
     try {
       normalizedOrigin = new URL(baseUrl.trim()).origin;
     } catch {
-      setSaveState({
-        kind: "error",
-        messageKey: "error.validation",
-        params: { message: "Invalid URL" },
-      });
+      setSaveState({ kind: "error", messageKey: "error.invalidUrl" });
       return;
     }
 

--- a/browser-extensions/src/components/ConfigForm.tsx
+++ b/browser-extensions/src/components/ConfigForm.tsx
@@ -73,11 +73,43 @@ export function ConfigForm({ t, initial, onSaved, showCancel, onCancel }: Props)
   async function handleTest() {
     if (!formValid) return;
     setTestState({ kind: "running" });
+
+    // Mirror handleSave's normalization and permission request: without the
+    // origin-only URL and a granted host permission, the fetch below is
+    // subject to the same-origin/CORS restrictions of a normal page and a
+    // reachable server is reported as a network failure.
+    let origin: string;
     try {
-      await testConnection({ baseUrl: baseUrl.trim(), apiKey: trimmedKey });
+      origin = new URL(baseUrl.trim()).origin;
+    } catch {
+      setTestState({
+        kind: "error",
+        messageKey: "error.validation",
+        params: { message: "Invalid URL" },
+      });
+      return;
+    }
+
+    let granted = false;
+    try {
+      granted = await chrome.permissions.request({ origins: [`${origin}/*`] });
+    } catch {
+      granted = false;
+    }
+    if (!granted) {
+      setTestState({
+        kind: "error",
+        messageKey: "error.permissionDeniedTest",
+        params: { host: hostFromBaseUrl(origin) },
+      });
+      return;
+    }
+
+    try {
+      await testConnection({ baseUrl: origin, apiKey: trimmedKey });
       setTestState({ kind: "ok" });
     } catch (err) {
-      const host = hostFromBaseUrl(baseUrl.trim());
+      const host = hostFromBaseUrl(origin);
       if (err instanceof ExtensionError) {
         const mapped = categoryToMessage(err.category);
         setTestState({

--- a/browser-extensions/src/i18n/en.ts
+++ b/browser-extensions/src/i18n/en.ts
@@ -58,6 +58,7 @@ const en = {
   "error.validation": "{message}",
   "error.clipboard": "Copy failed. Select the link above to copy it.",
   "error.permissionDenied": "shrtnr needs permission to talk to {host}. Click Save again and accept.",
+  "error.permissionDeniedTest": "shrtnr needs permission to talk to {host}. Click Test again and accept.",
   "error.tabUnknown": "Couldn't read the active tab.",
 
   // Options page

--- a/browser-extensions/src/i18n/en.ts
+++ b/browser-extensions/src/i18n/en.ts
@@ -56,6 +56,7 @@ const en = {
   "error.rateLimited": "Too many requests. Try again in a moment.",
   "error.server": "Your shrtnr server returned an error.",
   "error.validation": "{message}",
+  "error.invalidUrl": "That's not a valid URL. Use the full address, like https://your-shrtnr.example.com.",
   "error.clipboard": "Copy failed. Select the link above to copy it.",
   "error.permissionDenied": "shrtnr needs permission to talk to {host}. Click Save again and accept.",
   "error.permissionDeniedTest": "shrtnr needs permission to talk to {host}. Click Test again and accept.",

--- a/browser-extensions/src/i18n/en.ts
+++ b/browser-extensions/src/i18n/en.ts
@@ -57,6 +57,7 @@ const en = {
   "error.server": "Your shrtnr server returned an error.",
   "error.validation": "{message}",
   "error.invalidUrl": "That's not a valid URL. Use the full address, like https://your-shrtnr.example.com.",
+  "error.saveFailed": "Couldn't save your settings. Try again.",
   "error.clipboard": "Copy failed. Select the link above to copy it.",
   "error.permissionDenied": "shrtnr needs permission to talk to {host}. Click Save again and accept.",
   "error.permissionDeniedTest": "shrtnr needs permission to talk to {host}. Click Test again and accept.",

--- a/browser-extensions/src/i18n/id.ts
+++ b/browser-extensions/src/i18n/id.ts
@@ -60,6 +60,7 @@ const id: Translations = {
   "error.validation": "{message}",
   "error.clipboard": "Penyalinan gagal. Pilih tautan di atas untuk menyalinnya.",
   "error.permissionDenied": "shrtnr memerlukan izin untuk berkomunikasi dengan {host}. Klik Simpan lagi dan setujui.",
+  "error.permissionDeniedTest": "shrtnr memerlukan izin untuk berkomunikasi dengan {host}. Klik Uji lagi dan setujui.",
   "error.tabUnknown": "Tidak dapat membaca tab aktif.",
 
   // Options page

--- a/browser-extensions/src/i18n/id.ts
+++ b/browser-extensions/src/i18n/id.ts
@@ -59,6 +59,7 @@ const id: Translations = {
   "error.server": "Server shrtnr Anda mengembalikan kesalahan.",
   "error.validation": "{message}",
   "error.invalidUrl": "URL tidak valid. Gunakan alamat lengkap, seperti https://shrtnr-anda.example.com.",
+  "error.saveFailed": "Gagal menyimpan pengaturan. Coba lagi.",
   "error.clipboard": "Penyalinan gagal. Pilih tautan di atas untuk menyalinnya.",
   "error.permissionDenied": "shrtnr memerlukan izin untuk berkomunikasi dengan {host}. Klik Simpan lagi dan setujui.",
   "error.permissionDeniedTest": "shrtnr memerlukan izin untuk berkomunikasi dengan {host}. Klik Uji lagi dan setujui.",

--- a/browser-extensions/src/i18n/id.ts
+++ b/browser-extensions/src/i18n/id.ts
@@ -58,6 +58,7 @@ const id: Translations = {
   "error.rateLimited": "Terlalu banyak permintaan. Coba lagi sebentar.",
   "error.server": "Server shrtnr Anda mengembalikan kesalahan.",
   "error.validation": "{message}",
+  "error.invalidUrl": "URL tidak valid. Gunakan alamat lengkap, seperti https://shrtnr-anda.example.com.",
   "error.clipboard": "Penyalinan gagal. Pilih tautan di atas untuk menyalinnya.",
   "error.permissionDenied": "shrtnr memerlukan izin untuk berkomunikasi dengan {host}. Klik Simpan lagi dan setujui.",
   "error.permissionDeniedTest": "shrtnr memerlukan izin untuk berkomunikasi dengan {host}. Klik Uji lagi dan setujui.",

--- a/browser-extensions/src/i18n/sv.ts
+++ b/browser-extensions/src/i18n/sv.ts
@@ -60,6 +60,7 @@ const sv: Translations = {
   "error.validation": "{message}",
   "error.clipboard": "Kopiering misslyckades. Markera länken ovan för att kopiera den.",
   "error.permissionDenied": "shrtnr behöver tillstånd att kommunicera med {host}. Klicka på Spara igen och godkänn.",
+  "error.permissionDeniedTest": "shrtnr behöver tillstånd att kommunicera med {host}. Klicka på Testa igen och godkänn.",
   "error.tabUnknown": "Kunde inte läsa den aktiva fliken.",
 
   // Options page

--- a/browser-extensions/src/i18n/sv.ts
+++ b/browser-extensions/src/i18n/sv.ts
@@ -59,6 +59,7 @@ const sv: Translations = {
   "error.server": "Din shrtnr-server returnerade ett fel.",
   "error.validation": "{message}",
   "error.invalidUrl": "Ogiltig URL. Använd hela adressen, till exempel https://din-shrtnr.example.com.",
+  "error.saveFailed": "Det gick inte att spara inställningarna. Försök igen.",
   "error.clipboard": "Kopiering misslyckades. Markera länken ovan för att kopiera den.",
   "error.permissionDenied": "shrtnr behöver tillstånd att kommunicera med {host}. Klicka på Spara igen och godkänn.",
   "error.permissionDeniedTest": "shrtnr behöver tillstånd att kommunicera med {host}. Klicka på Testa igen och godkänn.",

--- a/browser-extensions/src/i18n/sv.ts
+++ b/browser-extensions/src/i18n/sv.ts
@@ -58,6 +58,7 @@ const sv: Translations = {
   "error.rateLimited": "För många förfrågningar. Försök igen om en stund.",
   "error.server": "Din shrtnr-server returnerade ett fel.",
   "error.validation": "{message}",
+  "error.invalidUrl": "Ogiltig URL. Använd hela adressen, till exempel https://din-shrtnr.example.com.",
   "error.clipboard": "Kopiering misslyckades. Markera länken ovan för att kopiera den.",
   "error.permissionDenied": "shrtnr behöver tillstånd att kommunicera med {host}. Klicka på Spara igen och godkänn.",
   "error.permissionDeniedTest": "shrtnr behöver tillstånd att kommunicera med {host}. Klicka på Testa igen och godkänn.",

--- a/browser-extensions/tests/i18n.test.ts
+++ b/browser-extensions/tests/i18n.test.ts
@@ -46,6 +46,17 @@ describe("i18n.createTranslateFn", () => {
     expect(t("error.validation", { message: "URL too long" })).toBe("URL too long");
   });
 
+  it("localizes the invalid-URL error instead of passing English through", () => {
+    // error.validation is a "{message}" passthrough for server-supplied text.
+    // A client-side URL parse failure must carry its own localized key.
+    const enText = createTranslateFn("en")("error.invalidUrl");
+    const idText = createTranslateFn("id")("error.invalidUrl");
+    const svText = createTranslateFn("sv")("error.invalidUrl");
+    expect(enText).not.toBe("error.invalidUrl");
+    expect(idText).not.toBe(enText);
+    expect(svText).not.toBe(enText);
+  });
+
   it("returns the key itself when missing in both target and fallback", () => {
     const t = createTranslateFn("en");
     // @ts-expect-error: deliberately passing an unknown key

--- a/browser-extensions/tests/i18n.test.ts
+++ b/browser-extensions/tests/i18n.test.ts
@@ -57,6 +57,15 @@ describe("i18n.createTranslateFn", () => {
     expect(svText).not.toBe(enText);
   });
 
+  it("localizes the save-failure message", () => {
+    const enText = createTranslateFn("en")("error.saveFailed");
+    const idText = createTranslateFn("id")("error.saveFailed");
+    const svText = createTranslateFn("sv")("error.saveFailed");
+    expect(enText).not.toBe("error.saveFailed");
+    expect(idText).not.toBe(enText);
+    expect(svText).not.toBe(enText);
+  });
+
   it("returns the key itself when missing in both target and fallback", () => {
     const t = createTranslateFn("en");
     // @ts-expect-error: deliberately passing an unknown key

--- a/browser-extensions/tests/options.test.tsx
+++ b/browser-extensions/tests/options.test.tsx
@@ -218,6 +218,47 @@ describe("Options — Save", () => {
     expect(await getConfig()).toBeNull();
   });
 
+  it("shows a localized message when the browser rejects the write with an Error", async () => {
+    // chrome.storage error strings are English-only browser internals, so
+    // surfacing err.message leaks English into id/sv installs.
+    chrome.permissions.request = vi.fn(async () => true);
+    await renderOptions();
+    await waitFor(() => screen.getByLabelText(/server url/i));
+    chrome.storage.sync.set = vi.fn(async () => {
+      throw new Error("QUOTA_BYTES_PER_ITEM quota exceeded");
+    });
+    fireEvent.input(screen.getByLabelText(/server url/i), {
+      target: { value: "https://x.com" },
+    });
+    fireEvent.input(screen.getByLabelText(/api key/i), {
+      target: { value: "sk_abc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't save your settings/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(/QUOTA_BYTES_PER_ITEM/)).toBeNull();
+  });
+
+  it("shows the same localized message when the write rejects with a non-Error", async () => {
+    chrome.permissions.request = vi.fn(async () => true);
+    await renderOptions();
+    await waitFor(() => screen.getByLabelText(/server url/i));
+    chrome.storage.sync.set = vi.fn(async () => {
+      throw "boom";
+    });
+    fireEvent.input(screen.getByLabelText(/server url/i), {
+      target: { value: "https://x.com" },
+    });
+    fireEvent.input(screen.getByLabelText(/api key/i), {
+      target: { value: "sk_abc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't save your settings/i)).toBeTruthy();
+    });
+  });
+
   it("Save button is disabled when fields empty", async () => {
     await renderOptions();
     await waitFor(() => screen.getByRole("button", { name: /^save$/i }));

--- a/browser-extensions/tests/options.test.tsx
+++ b/browser-extensions/tests/options.test.tsx
@@ -48,6 +48,7 @@ describe("Options — banner visibility", () => {
 
 describe("Options — Test connection", () => {
   it("shows connected status on success", async () => {
+    chrome.permissions.request = vi.fn(async () => true);
     await renderOptions();
     await waitFor(() => screen.getByLabelText(/server url/i));
     fireEvent.input(screen.getByLabelText(/server url/i), {
@@ -60,6 +61,63 @@ describe("Options — Test connection", () => {
     await waitFor(() => {
       expect(screen.getByText(/connected/i)).toBeTruthy();
     });
+  });
+
+  it("requests host permission before testing", async () => {
+    chrome.permissions.request = vi.fn(async () => true);
+    await renderOptions();
+    await waitFor(() => screen.getByLabelText(/server url/i));
+    fireEvent.input(screen.getByLabelText(/server url/i), {
+      target: { value: "https://x.com" },
+    });
+    fireEvent.input(screen.getByLabelText(/api key/i), {
+      target: { value: "sk_abc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /test/i }));
+    await waitFor(() => {
+      expect(chrome.permissions.request).toHaveBeenCalledWith({
+        origins: ["https://x.com/*"],
+      });
+    });
+    await waitFor(() => {
+      expect(mockedTest).toHaveBeenCalledWith({ baseUrl: "https://x.com", apiKey: "sk_abc" });
+    });
+  });
+
+  it("normalizes a server URL with a path to its origin before testing", async () => {
+    // A URL copied from the address bar (with a path) must resolve the same
+    // way handleSave does, or a server that will work fine once saved tests
+    // as unreachable.
+    chrome.permissions.request = vi.fn(async () => true);
+    await renderOptions();
+    await waitFor(() => screen.getByLabelText(/server url/i));
+    fireEvent.input(screen.getByLabelText(/server url/i), {
+      target: { value: "https://x.com/_/admin" },
+    });
+    fireEvent.input(screen.getByLabelText(/api key/i), {
+      target: { value: "sk_abc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /test/i }));
+    await waitFor(() => {
+      expect(mockedTest).toHaveBeenCalledWith({ baseUrl: "https://x.com", apiKey: "sk_abc" });
+    });
+  });
+
+  it("shows a permission error and does not call testConnection when permission is denied", async () => {
+    chrome.permissions.request = vi.fn(async () => false);
+    await renderOptions();
+    await waitFor(() => screen.getByLabelText(/server url/i));
+    fireEvent.input(screen.getByLabelText(/server url/i), {
+      target: { value: "https://x.com" },
+    });
+    fireEvent.input(screen.getByLabelText(/api key/i), {
+      target: { value: "sk_abc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /test/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/needs permission/i)).toBeTruthy();
+    });
+    expect(mockedTest).not.toHaveBeenCalled();
   });
 
   it("shows the auth error message on 401", async () => {

--- a/browser-extensions/tests/options.test.tsx
+++ b/browser-extensions/tests/options.test.tsx
@@ -120,6 +120,26 @@ describe("Options — Test connection", () => {
     expect(mockedTest).not.toHaveBeenCalled();
   });
 
+  it("shows a localized invalid-URL error and skips the permission request", async () => {
+    // error.validation is a "{message}" passthrough, so feeding it an English
+    // literal leaks English into id/sv installs.
+    chrome.permissions.request = vi.fn(async () => true);
+    await renderOptions();
+    await waitFor(() => screen.getByLabelText(/server url/i));
+    fireEvent.input(screen.getByLabelText(/server url/i), {
+      target: { value: "not a url" },
+    });
+    fireEvent.input(screen.getByLabelText(/api key/i), {
+      target: { value: "sk_abc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /test/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/not a valid url/i)).toBeTruthy();
+    });
+    expect(chrome.permissions.request).not.toHaveBeenCalled();
+    expect(mockedTest).not.toHaveBeenCalled();
+  });
+
   it("shows the auth error message on 401", async () => {
     mockedTest.mockRejectedValue(new ExtensionError("unauthorized", "bad", 401));
     await renderOptions();
@@ -175,6 +195,25 @@ describe("Options — Save", () => {
     await waitFor(() => {
       expect(screen.getByText(/needs permission/i)).toBeTruthy();
     });
+    const { getConfig } = await import("../src/storage");
+    expect(await getConfig()).toBeNull();
+  });
+
+  it("shows a localized invalid-URL error and does not persist", async () => {
+    chrome.permissions.request = vi.fn(async () => true);
+    await renderOptions();
+    await waitFor(() => screen.getByLabelText(/server url/i));
+    fireEvent.input(screen.getByLabelText(/server url/i), {
+      target: { value: "not a url" },
+    });
+    fireEvent.input(screen.getByLabelText(/api key/i), {
+      target: { value: "sk_abc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/not a valid url/i)).toBeTruthy();
+    });
+    expect(chrome.permissions.request).not.toHaveBeenCalled();
     const { getConfig } = await import("../src/storage");
     expect(await getConfig()).toBeNull();
   });

--- a/sdk/typescript/src/internal/http.ts
+++ b/sdk/typescript/src/internal/http.ts
@@ -67,9 +67,13 @@ export class HttpClient {
     }
 
     if (!res.ok) {
+      // Read and parse in separate steps, same as the success path below: a
+      // connection reset while streaming an error body is a transport
+      // failure (status 0), not the server's declared HTTP status.
+      const text = await this.readBody(res);
       let serverMessage = `HTTP ${res.status}`;
       try {
-        const json = (await res.json()) as { error?: string };
+        const json = JSON.parse(text) as { error?: string };
         if (typeof json.error === "string") serverMessage = json.error;
       } catch {
         // ignore parse failure; keep default message
@@ -115,9 +119,13 @@ export class HttpClient {
     }
 
     if (!res.ok) {
+      // Read and parse in separate steps, same as the success path below: a
+      // connection reset while streaming an error body is a transport
+      // failure (status 0), not the server's declared HTTP status.
+      const text = await this.readBody(res);
       let serverMessage = `HTTP ${res.status}`;
       try {
-        const json = (await res.json()) as { error?: string };
+        const json = JSON.parse(text) as { error?: string };
         if (typeof json.error === "string") serverMessage = json.error;
       } catch {
         // ignore parse failure; keep default message

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -243,6 +243,21 @@ describe("Error handling", () => {
     }
   });
 
+  it("reports status 0 when the connection drops mid-body on an error response", async () => {
+    // The error branch read the body via res.json() directly, so a
+    // connection reset while streaming a 500's error body was swallowed by
+    // the catch and reported as ShrtnrError(500, "HTTP 500") instead of the
+    // status-0 transport failure every other read path reports.
+    fetchSpy.mockResolvedValueOnce(new Response(erroringBody(), { status: 500 }));
+    try {
+      await client().links.list();
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ShrtnrError);
+      expect((e as ShrtnrError).status).toBe(0);
+    }
+  });
+
   it("wraps a mid-body stream failure on a text response in ShrtnrError", async () => {
     // requestText handed back res.text() unwrapped, so a reset partway
     // through a QR download escaped as a raw TypeError past the documented
@@ -250,6 +265,25 @@ describe("Error handling", () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(erroringBody(), {
         status: 200,
+        headers: { "Content-Type": "image/svg+xml" },
+      }),
+    );
+    try {
+      await client().links.qr(5);
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ShrtnrError);
+      expect((e as ShrtnrError).status).toBe(0);
+    }
+  });
+
+  it("reports status 0 when the connection drops mid-body on a non-2xx text response", async () => {
+    // requestText's error branch had the same res.json()-without-readBody
+    // gap as request(): a reset while streaming a non-2xx QR error body
+    // reported the stale HTTP status instead of status 0.
+    fetchSpy.mockResolvedValueOnce(
+      new Response(erroringBody(), {
+        status: 500,
         headers: { "Content-Type": "image/svg+xml" },
       }),
     );

--- a/src/__tests__/admin/widgets/dashboard/recent-links.test.tsx
+++ b/src/__tests__/admin/widgets/dashboard/recent-links.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import { applyMigrations, resetData } from "../../../setup";
 import { LinkRepository } from "../../../../db";
+import { addCustomSlugToLink, setSlugPrimary } from "../../../../services/link-management";
 import { recentLinksWidget } from "../../../../admin/widgets/dashboard/recent-links";
 import type { WidgetCtx } from "../../../../admin/widgets/types";
 
@@ -50,6 +51,18 @@ describe("dashboard.recent-links widget", () => {
     // The htmx placeholder already carries the bento-card shell, so the widget
     // must render inner content only and not nest its own outer wrapper.
     expect(out).not.toContain("bento-card");
+  });
+
+  it("shows a custom slug the owner set as primary, not the auto-generated one", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://e.com", slug: "auto123" });
+    await addCustomSlugToLink(env as any, link.id, { slug: "promo" });
+    await setSlugPrimary(env as any, link.id, "promo", "anonymous");
+
+    const data = await recentLinksWidget.load(env, ctx, { range: "all" });
+    const out = String(recentLinksWidget.render(data, ctx));
+
+    expect(out).toContain('data-copy-slug="promo"');
+    expect(out).not.toContain('data-copy-slug="auto123"');
   });
 
   it("exposes the copy chip via data-copy-slug, not an inline onclick", async () => {

--- a/src/__tests__/admin/widgets/dashboard/top-links.test.tsx
+++ b/src/__tests__/admin/widgets/dashboard/top-links.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import { applyMigrations, resetData } from "../../../setup";
 import { LinkRepository, ClickRepository } from "../../../../db";
+import { addCustomSlugToLink, setSlugPrimary } from "../../../../services/link-management";
 import { topLinksWidget } from "../../../../admin/widgets/dashboard/top-links";
 import type { WidgetCtx } from "../../../../admin/widgets/types";
 
@@ -47,5 +48,15 @@ describe("dashboard.top-links widget", () => {
     expect(data.rows[0].slug).toBe("primo");
     const out = String(topLinksWidget.render(data, ctx));
     expect(out).toContain("primo"); // primary slug shown, matching the page
+  });
+
+  it("names a row by the custom slug the owner set as primary, not the auto-generated one", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://e.com", slug: "auto123" });
+    await addCustomSlugToLink(env as any, link.id, { slug: "promo" });
+    await setSlugPrimary(env as any, link.id, "promo", "anonymous");
+    await ClickRepository.record(env.DB, "promo", {});
+
+    const data = await topLinksWidget.load(env, ctx, { range: "all" });
+    expect(data.rows[0].slug).toBe("promo");
   });
 });

--- a/src/__tests__/page/keys-page.test.ts
+++ b/src/__tests__/page/keys-page.test.ts
@@ -110,6 +110,20 @@ describe("Keys page table", () => {
     expect(html).not.toContain(`${prefix}&hellip;`);
   });
 
+  it("translates the scope badge instead of rendering the raw scope token", async () => {
+    await seedApiKey();
+    const html = await fetchKeysHtml();
+    expect(html).toMatch(/class="scope-badge create"[^>]*>Create</);
+    expect(html).not.toMatch(/class="scope-badge create"[^>]*>create</);
+  });
+
+  it("localizes the scope badge for a non-English locale", async () => {
+    await seedApiKey();
+    const res = await SELF.fetch(authed("/_/admin/keys", { headers: { Cookie: "lang=id" } }));
+    const html = await res.text();
+    expect(html).toMatch(/class="scope-badge create"[^>]*>Buat</);
+  });
+
   it("keeps the delete action for each key", async () => {
     await seedApiKey();
     const html = await fetchKeysHtml();

--- a/src/__tests__/service/ownership.test.ts
+++ b/src/__tests__/service/ownership.test.ts
@@ -168,6 +168,45 @@ describe("Slug ownership: disable", () => {
   });
 });
 
+describe("Slug case sensitivity: mutation endpoints match stored (lowercase) slugs", () => {
+  it("disableSlug matches a differently-cased slug argument", async () => {
+    const link = await createOwnedLink();
+    await addCustomSlugToLink(env as any, link.id, { slug: "custom-slug" });
+
+    const result = await disableSlug(env as any, link.id, "Custom-Slug", OWNER);
+    expect(result.ok).toBe(true);
+  });
+
+  it("enableSlug matches a differently-cased slug argument", async () => {
+    const link = await createOwnedLink();
+    await addCustomSlugToLink(env as any, link.id, { slug: "custom-slug" });
+    await disableSlug(env as any, link.id, "custom-slug", OWNER);
+
+    const result = await enableSlug(env as any, link.id, "CUSTOM-SLUG", OWNER);
+    expect(result.ok).toBe(true);
+  });
+
+  it("removeSlug matches a differently-cased slug argument", async () => {
+    const link = await createOwnedLink();
+    await addCustomSlugToLink(env as any, link.id, { slug: "custom-slug" });
+
+    const result = await removeSlug(env as any, link.id, "Custom-Slug", OWNER);
+    expect(result.ok).toBe(true);
+  });
+
+  it("setSlugPrimary matches a differently-cased slug argument", async () => {
+    const link = await createOwnedLink();
+    await addCustomSlugToLink(env as any, link.id, { slug: "custom-slug" });
+
+    const result = await setSlugPrimary(env as any, link.id, "Custom-Slug", OWNER);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const primary = result.data.slugs.find((s) => s.is_primary === 1);
+      expect(primary?.slug).toBe("custom-slug");
+    }
+  });
+});
+
 describe("Slug ownership: enable", () => {
   it("link owner can enable a disabled slug", async () => {
     const link = await createOwnedLink();

--- a/src/admin/widgets/dashboard/recent-links.tsx
+++ b/src/admin/widgets/dashboard/recent-links.tsx
@@ -11,11 +11,12 @@ interface RecentLinksData {
 }
 
 /**
- * Mirrors the primary-slug pick on the dashboard page: the first
- * auto-generated slug, falling back to the first slug of any kind.
+ * Picks the slug marked is_primary, falling back to the first auto-generated
+ * slug, then the first slug of any kind. Mirrors the primary-slug pick used
+ * on the link list and detail pages.
  */
 function primarySlug(link: LinkWithSlugs): string {
-  const p = link.slugs.find((s) => !s.is_custom);
+  const p = link.slugs.find((s) => s.is_primary) ?? link.slugs.find((s) => !s.is_custom);
   return p ? p.slug : link.slugs[0]?.slug || "";
 }
 

--- a/src/db/link-repository.ts
+++ b/src/db/link-repository.ts
@@ -270,11 +270,10 @@ export class LinkRepository {
 
   /**
    * Batch-resolve the display slug for a set of link ids in one query. Picks
-   * the primary slug per link the way the dashboard does: the first
-   * auto-generated (non-custom) slug, falling back to the first slug of any
-   * kind. Mirrors the `is_custom ASC, created_at ASC` ordering the slug loaders
-   * use, so the pick matches recent-links exactly. Returns a Map keyed by
-   * link_id; ids with no slug are absent.
+   * the slug marked is_primary per link, falling back to the first
+   * auto-generated (non-custom) slug, then the first slug of any kind, so the
+   * pick matches the one used on the link list and detail pages. Returns a
+   * Map keyed by link_id; ids with no slug are absent.
    */
   static async primarySlugByIds(db: D1Database, ids: number[]): Promise<Map<number, string>> {
     const out = new Map<number, string>();
@@ -283,7 +282,7 @@ export class LinkRepository {
     const rows = await db
       .prepare(
         `SELECT link_id, slug FROM slugs WHERE link_id IN (${placeholders})
-         ORDER BY is_custom ASC, created_at ASC`,
+         ORDER BY is_primary DESC, is_custom ASC, created_at ASC`,
       )
       .bind(...ids)
       .all<{ link_id: number; slug: string }>();

--- a/src/pages/keys.tsx
+++ b/src/pages/keys.tsx
@@ -8,6 +8,12 @@ import { SdkList } from "./sdk-list";
 // Bullets that stand in for the redacted tail of a key prefix, e.g. sk_84cc••••••.
 const KEY_MASK = "••••••";
 
+function scopeLabel(scope: string, t: TranslateFn): string {
+  if (scope === "create") return t("client.scopeCreate");
+  if (scope === "read") return t("client.scopeRead");
+  return scope;
+}
+
 function formatDate(ts: number, lang: string): string {
   const d = new Date(ts * 1000);
   return d.toLocaleDateString(lang, {
@@ -132,7 +138,7 @@ export const KeysPage: FC<Props> = ({ keys, t, lang, origin }) => {
                       <td data-label={t("keys.colScope")}>
                         <span class="scope-badges">
                           {scopes.map((s) => (
-                            <span class={`scope-badge ${s}`}>{s}</span>
+                            <span class={`scope-badge ${s}`}>{scopeLabel(s, t)}</span>
                           ))}
                         </span>
                       </td>

--- a/src/services/link-management.ts
+++ b/src/services/link-management.ts
@@ -297,6 +297,7 @@ export async function setSlugPrimary(
   slug: string,
   identity: string,
 ): Promise<ServiceResult<LinkWithSlugs>> {
+  slug = slug.toLowerCase();
   const link = await LinkRepository.getById(env.DB, linkId);
   if (!link) return fail(404, "Link not found");
   if (link.created_by !== identity) return fail(403, "Only the link owner can change the primary slug");
@@ -316,6 +317,7 @@ export async function disableSlug(
   slug: string,
   identity: string,
 ): Promise<ServiceResult<Slug>> {
+  slug = slug.toLowerCase();
   const link = await LinkRepository.getById(env.DB, linkId);
   if (!link) return fail(404, "Link not found");
   if (link.created_by !== identity) return fail(403, "Only the link owner can disable slugs on this link");
@@ -342,6 +344,7 @@ export async function enableSlug(
   slug: string,
   identity: string,
 ): Promise<ServiceResult<Slug>> {
+  slug = slug.toLowerCase();
   const link = await LinkRepository.getById(env.DB, linkId);
   if (!link) return fail(404, "Link not found");
   if (link.created_by !== identity) return fail(403, "Only the link owner can enable slugs on this link");
@@ -367,6 +370,7 @@ export async function removeSlug(
   slug: string,
   identity: string,
 ): Promise<ServiceResult<{ removed: boolean }>> {
+  slug = slug.toLowerCase();
   const link = await LinkRepository.getById(env.DB, linkId);
   if (!link) return fail(404, "Link not found");
   if (link.created_by !== identity) return fail(403, "Only the link owner can remove slugs on this link");


### PR DESCRIPTION
Weekly defect-hunting review of the app, API, and SDKs. Five confirmed defects fixed, each with a regression test that fails before the fix and passes after. Several additional findings needed a design/product judgment call and are flagged in PR comments instead of fixed.

## Fixes

**1. Case-sensitive slug lookup in slug mutation endpoints** (`src/services/link-management.ts`)
- Wrong: `setSlugPrimary`, `disableSlug`, `enableSlug`, and `removeSlug` matched the caller's slug against stored slugs with `===`, while `getLinkBySlug` and the redirect handler normalize to lowercase first. Slugs are always stored lowercase, and the path schema permits uppercase.
- Impact: a request against an existing slug with different casing (e.g. `Custom-Slug` vs stored `custom-slug`) spuriously returned 404.
- Fix: lowercase the slug argument at the top of each function.
- Test: `src/__tests__/service/ownership.test.ts` — 4 new cases, one per function.

**2. Dashboard widgets ignoring a link's `is_primary` slug** (`src/admin/widgets/dashboard/recent-links.tsx`, `src/db/link-repository.ts`)
- Wrong: `recentLinksWidget`'s slug picker and `LinkRepository.primarySlugByIds` (used by Most Clicked) both picked the first auto-generated slug, never checking `is_primary`.
- Impact: once an owner sets a custom slug as primary (a normal, supported action), the link list/detail pages correctly show it, but the dashboard's Recent Links and Most Clicked widgets kept showing the old auto-generated slug and copying the wrong URL.
- Fix: prefer the slug flagged `is_primary` in both places.
- Test: `recent-links.test.tsx`, `top-links.test.tsx` — new cases setting a custom slug as primary.

**3. Untranslated API key scope badges** (`src/pages/keys.tsx`)
- Wrong: the keys table rendered each scope badge as the literal token (`"create"`/`"read"`), while the New Key modal translates the same concept.
- Impact: non-English admin UIs showed English scope names in this one table.
- Fix: map each scope token through the existing `client.scopeCreate`/`client.scopeRead` keys.
- Test: `keys-page.test.ts` — English and Indonesian-locale assertions.

**4. TypeScript SDK swallowing transport failures on non-2xx responses** (`sdk/typescript/src/internal/http.ts`)
- Wrong: `request()`/`requestText()`'s error branch read the body via `res.json()` directly instead of the `readBody()` helper the success path already uses (added in 1.1.3 for this exact class of bug).
- Impact: a connection reset while streaming an *error* response body was swallowed by the catch and reported as `ShrtnrError(status, "HTTP {status}")` instead of `ShrtnrError(0, ...)`, unlike the success path and unlike Python/Dart, which are consistent here.
- Fix: route the error branch's body read through `readBody()` before parsing.
- Test: `client.test.ts` — mid-body stream failure on a 500 response, for both `request()` and `requestText()`.

**5. Broken "Test connection" in the browser extension** (`browser-extensions/src/components/ConfigForm.tsx`)
- Wrong: `handleTest()` called `testConnection()` directly, without requesting host permission (unlike `handleSave()`) and without normalizing the entered URL to its origin.
- Impact: host permission is optional/runtime-granted and the server sends no CORS headers on `/api/*`, so clicking "Test connection" against a correctly configured, reachable server on first use always reported it as unreachable. Separately, a URL pasted with a path (e.g. copied from the address bar) tested against the wrong path instead of the origin `Save` would actually use.
- Fix: request the host permission and normalize to origin in `handleTest`, mirroring `handleSave`. Adds `error.permissionDeniedTest` (en/id/sv) since the existing `permissionDenied` message says "Click Save again", which doesn't fit the Test button.
- Test: `options.test.tsx` — permission request, URL normalization, and permission-denied cases.

## Verification
- Two sub-agent-reported findings turned out to be false positives on closer inspection and were **not** fixed: a "disabled primary slug shown as live" claim (the transactional primary-handover in `SlugRepository.disable` already prevents this state from ever occurring) and a "raw range code shown untranslated" claim in `links.tsx` (an existing test explicitly asserts the raw code is the intended display, e.g. `Clicks (7d)`).
- Full test suites green: main app (1136 tests), TypeScript SDK (79 tests), browser extension (90 tests).

## Flagged for developer judgment (see PR comments)
- BigChart axis-label/granularity mismatch on the bundle detail chart
- `Bundle.accent` cross-SDK parity gap (Python throws, Dart defaults, TS silently undefined)
- `migrations/0004_slug_text_pk.sql` uses an INNER JOIN with no row-count verification
- `.github/workflows/migrate.yml`'s trigger condition may make the workflow permanently dead
- CLAUDE.md / docs/release-automation.md omit the browser-extension release track

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQuKTcRa3V8bGYqoJxdXk3)_