### PR TITLE
Weekly defect review: i18n interpolation, range localization, bundle stats, Python SDK redirects

### DIFF
--- a/sdk/python/src/shrtnr/client.py
+++ b/sdk/python/src/shrtnr/client.py
@@ -38,7 +38,9 @@ class Shrtnr:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._owns_client = http_client is None
-        self._http = http_client if http_client is not None else httpx.Client(timeout=timeout)
+        self._http = (
+            http_client if http_client is not None else httpx.Client(timeout=timeout, follow_redirects=True)
+        )
 
         self.links = Links(self._base_url, self._api_key, self._http)
         self.slugs = Slugs(self._base_url, self._api_key, self._http)
@@ -85,7 +87,9 @@ class AsyncShrtnr:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._owns_client = http_client is None
-        self._http = http_client if http_client is not None else httpx.AsyncClient(timeout=timeout)
+        self._http = (
+            http_client if http_client is not None else httpx.AsyncClient(timeout=timeout, follow_redirects=True)
+        )
 
         self.links = AsyncLinks(self._base_url, self._api_key, self._http)
         self.slugs = AsyncSlugs(self._base_url, self._api_key, self._http)

--- a/sdk/python/src/shrtnr/client.py
+++ b/sdk/python/src/shrtnr/client.py
@@ -39,7 +39,9 @@ class Shrtnr:
         self._api_key = api_key
         self._owns_client = http_client is None
         self._http = (
-            http_client if http_client is not None else httpx.Client(timeout=timeout, follow_redirects=True)
+            http_client
+            if http_client is not None
+            else httpx.Client(timeout=timeout, follow_redirects=True)
         )
 
         self.links = Links(self._base_url, self._api_key, self._http)
@@ -88,7 +90,9 @@ class AsyncShrtnr:
         self._api_key = api_key
         self._owns_client = http_client is None
         self._http = (
-            http_client if http_client is not None else httpx.AsyncClient(timeout=timeout, follow_redirects=True)
+            http_client
+            if http_client is not None
+            else httpx.AsyncClient(timeout=timeout, follow_redirects=True)
         )
 
         self.links = AsyncLinks(self._base_url, self._api_key, self._http)

--- a/sdk/python/tests/test_async_client.py
+++ b/sdk/python/tests/test_async_client.py
@@ -49,6 +49,18 @@ async def test_async_auth_sends_bearer_header(client: AsyncShrtnr) -> None:
     assert route.calls[0].request.headers["Authorization"] == f"Bearer {API_KEY}"
 
 
+@respx.mock
+async def test_async_follows_redirects_on_the_owned_client(client: AsyncShrtnr) -> None:
+    # See test_follows_redirects_on_the_owned_client in test_client.py:
+    # httpx.AsyncClient defaults to follow_redirects=False, unlike the
+    # TS/Dart SDKs, so the owned client must opt in explicitly.
+    respx.get(f"{BASE_URL}/_/api/links").mock(
+        return_value=httpx.Response(301, headers={"Location": f"{BASE_URL}/_/api/links/"}),
+    )
+    respx.get(f"{BASE_URL}/_/api/links/").mock(return_value=httpx.Response(200, json=[]))
+    assert await client.links.list() == []
+
+
 # ---- Errors ----
 
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -46,6 +46,20 @@ def test_auth_sends_bearer_header(client: Shrtnr) -> None:
     assert req.headers["Authorization"] == f"Bearer {API_KEY}"
 
 
+@respx.mock
+def test_follows_redirects_on_the_owned_client(client: Shrtnr) -> None:
+    # httpx.Client defaults to follow_redirects=False. The TS SDK (fetch,
+    # default "follow") and Dart SDK (http.Client, follows by default) both
+    # transparently follow a 3xx from the deployment's front door, so the
+    # owned httpx client must opt in too or the same base_url behaves
+    # differently depending on which SDK made the request.
+    respx.get(f"{BASE_URL}/_/api/links").mock(
+        return_value=httpx.Response(301, headers={"Location": f"{BASE_URL}/_/api/links/"}),
+    )
+    respx.get(f"{BASE_URL}/_/api/links/").mock(return_value=httpx.Response(200, json=[]))
+    assert client.links.list() == []
+
+
 # ---- Error handling ----
 
 

--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -83,6 +83,16 @@ describe("Links listing page", () => {
     expect(html).toMatch(/Clicks\s*\(7d\)/i);
   });
 
+  it("localizes the range in the clicks column header instead of showing the raw range key", async () => {
+    await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
+    const res = await SELF.fetch(req("/_/admin/links?range=24h", { headers: { Cookie: "lang=id" } }));
+    const html = await res.text();
+    // id.ts localizes "range.24h" to "24J"; the raw internal key "24h"
+    // must not leak through untranslated.
+    expect(html).toContain("Klik (24J)");
+    expect(html).not.toContain("(24h)");
+  });
+
   it("the displayed click total reflects the selected range", async () => {
     const link = await LinkRepository.create(env.DB, {
       url: "https://example.com",

--- a/src/__tests__/repository/click-repository.test.ts
+++ b/src/__tests__/repository/click-repository.test.ts
@@ -484,6 +484,30 @@ describe("ClickRepository.getBundleStats", () => {
     expect(stats.countries_reached).toBe(12);
   });
 
+  it("computes top_country pct against the full total, not just the top-10 list sum", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://a.com", slug: "aaa", createdBy: "a@b" });
+    const bundle = await BundleRepository.create(env.DB, { name: "OSS", createdBy: "a@b" });
+    await BundleRepository.addLink(env.DB, bundle.id, link.id);
+
+    // 11 distinct countries: US clearly on top with 4 clicks, and 10 more
+    // tied at 1 click each so the top-10 list (capped at LIMIT 10) drops one
+    // of them. The true total (14) differs from the top-10 sum (13).
+    const now = Math.floor(Date.now() / 1000);
+    let at = now;
+    for (let i = 0; i < 4; i++) await recordClick(link.slugs[0].slug, at--, { country: "US" });
+    for (const code of ["AA", "BB", "CC", "DD", "EE", "FF", "GG", "HH", "II", "JJ"]) {
+      await recordClick(link.slugs[0].slug, at--, { country: code });
+    }
+
+    const stats = (await ClickRepository.getBundleStats(env.DB, bundle.id, "30d"))!;
+    expect(stats.total_clicks).toBe(14);
+    expect(stats.countries).toHaveLength(10);
+    expect(stats.top_country?.name).toBe("US");
+    // Math.round(4 / 14 * 100) = 29. The old code divided by the top-10
+    // sum (13) instead, which would have produced 31.
+    expect(stats.top_country?.pct).toBe(29);
+  });
+
   it("sorts per_link by click count descending and computes pct_of_bundle", async () => {
     const link1 = await LinkRepository.create(env.DB, { url: "https://a.com", slug: "aaa", createdBy: "a@b" });
     const link2 = await LinkRepository.create(env.DB, { url: "https://b.com", slug: "bbb", createdBy: "a@b" });

--- a/src/__tests__/unit/i18n.test.ts
+++ b/src/__tests__/unit/i18n.test.ts
@@ -82,6 +82,16 @@ describe("i18n", () => {
       );
     });
 
+    it("treats interpolated values as literal text, not replacement patterns", () => {
+      const t = createTranslateFn("en");
+      // "$`" is a special String.replace pattern (text before the match).
+      // A naive string replacement would splice it in instead of the
+      // literal value.
+      expect(t("client.confirmDeleteKey", { title: "x$`y" })).toBe(
+        'Delete API key "x$`y"? This cannot be undone.',
+      );
+    });
+
     it("returns the key itself when no translation exists", () => {
       // Simulate a missing key by casting
       const t = createTranslateFn("en");

--- a/src/db/click-repository.ts
+++ b/src/db/click-repository.ts
@@ -1176,9 +1176,11 @@ export class ClickRepository {
     }
 
     const countriesList = countries.results ?? [];
-    const countriesTotal = countriesList.reduce((s, c) => s + c.count, 0);
+    // Denominator must be the bundle's full click total, not the sum of the
+    // top-10 countries list: with more than 10 distinct countries, summing
+    // only the listed ones inflates the top country's share.
     const topCountry = countriesList[0]
-      ? { name: countriesList[0].name, pct: countriesTotal > 0 ? Math.round((countriesList[0].count / countriesTotal) * 100) : 0 }
+      ? { name: countriesList[0].name, pct: totalClicks > 0 ? Math.round((countriesList[0].count / totalClicks) * 100) : 0 }
       : undefined;
 
     const top = perLink[0] && perLink[0].click_count > 0 ? perLink[0] : undefined;

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -32,7 +32,10 @@ export function createTranslateFn(lang: string): TranslateFn {
     let value = strings[key] || fallback[key] || key;
     if (params) {
       for (const [k, v] of Object.entries(params)) {
-        value = value.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+        // Replacer function, not a string: a string replacement treats
+        // "$&", "$`", "$'", "$1" etc. in the value as special patterns
+        // instead of literal text.
+        value = value.replace(new RegExp(`\\{${k}\\}`, "g"), () => String(v));
       }
     }
     return value;

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -95,7 +95,7 @@ export const LinksPage: FC<Props> = ({
     { key: "all", labelKey: "links.filterAll", icon: "all_inclusive" },
   ];
 
-  const rangeLabel = range === "all" ? t("range.long.all") : range;
+  const rangeLabel = range === "all" ? t("range.long.all") : t(`range.${range}` as const);
   const preserveParams: Record<string, string | undefined> = {
     sort,
     filter,


### PR DESCRIPTION
Weekly automated defect-hunting review across the app, API, and all three SDKs. Four fixes qualified (unambiguous, local, low-risk, test-covered); everything else is left as a PR comment for a judgment call.

## Fixes

### 1. i18n interpolation corrupted by `String.replace` special patterns
`createTranslateFn` substituted `{param}` placeholders with `value.replace(regex, String(v))`. A *string* replacement argument treats `$&`, `` $` ``, `$'`, `$1` etc. as special patterns, not literal text. Any interpolated value containing one of those sequences — an API key title, a bundle name, a link URL, all user-controlled free text — silently corrupted the rendered confirm-dialog/toast copy.

**Fix:** pass a replacer function so the value always splices in literally. **Test:** `src/__tests__/unit/i18n.test.ts` reproduces the corruption with a `` "x$`y" `` value.

### 2. Clicks column header showed the raw range key untranslated
The links page's "Clicks ({range})" header substituted the raw internal range key (`"24h"`) instead of going through `t()`, unlike every other range display in the codebase. Cosmetic in English, wrong in `id`/`sv` (showed `"24h"` instead of `"24J"`/`"24T"`).

**Fix:** route it through `t(`range.${range}`)`, matching the pattern used elsewhere. **Test:** requests the links page in the `id` locale and asserts the localized label appears.

### 3. Bundle `top_country.pct` computed against the wrong denominator
`getBundleStats`'s countries list is capped at `LIMIT 10`; `top_country.pct` divided the leading country's count by the sum of only that top-10 list instead of the bundle's true `total_clicks`. Once a bundle spans more than 10 distinct countries, the pct is inflated. The sibling field `per_link[].pct_of_bundle` already uses the correct denominator a few lines above.

**Fix:** use `totalClicks` for both fields. **Test:** seeds 11 distinct countries (one dominant, ten tied at the LIMIT-10 cutoff) so the two denominators diverge, and asserts the corrected value.

### 4. Python SDK didn't follow redirects
`httpx.Client`/`AsyncClient` default to `follow_redirects=False`. Neither `Shrtnr` nor `AsyncShrtnr` overrode that on the client they own. The TypeScript SDK (`fetch`, default "follow") and Dart SDK (`http.Client`, follows by default) both handle a 3xx from a deployment's front door transparently; Python raised `ShrtnrError` for the identical request. Single-SDK fix: TS/Dart already behave the way this brings Python in line with.

**Fix:** pass `follow_redirects=True` when constructing the owned client. **Tests:** sync and async tests mock a 301→200 chain and assert the request completes.

All four regression tests were confirmed to fail on the pre-fix code and pass after.

## Verification
- `yarn test`: 1131/1131 passed
- `npx tsc --noEmit`: clean
- Python: `pytest` 97/97 passed, `ruff check` clean, `mypy` clean

## Flagged for developer judgment (not fixed here)
See PR comment below — items needing a design/product decision, an SDK-surface change, or that couldn't be pinned to a confirmed advisory.


---
_Generated by [Claude Code](https://claude.ai/code/session_01APLGs6UxvVhopjC1x21VY2)_