### PR TITLE
Fix links pagination overflow for large datasets

### DIFF
--- a/src/__tests__/unit/links-pagination.test.ts
+++ b/src/__tests__/unit/links-pagination.test.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { paginationItems } from "../../pages/links";
+
+describe("links pagination window", () => {
+  it("shows every page when the result fits in the compact window", () => {
+    expect(paginationItems(1, 7)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it("keeps the first pages and last page visible near the start", () => {
+    expect(paginationItems(1, 188)).toEqual([1, 2, 3, 4, 5, "ellipsis", 188]);
+  });
+
+  it("centers the current page between stable first and last links", () => {
+    expect(paginationItems(94, 188)).toEqual([
+      1,
+      "ellipsis",
+      93,
+      94,
+      95,
+      "ellipsis",
+      188,
+    ]);
+  });
+
+  it("keeps the first page and last pages visible near the end", () => {
+    expect(paginationItems(188, 188)).toEqual([
+      1,
+      "ellipsis",
+      184,
+      185,
+      186,
+      187,
+      188,
+    ]);
+  });
+});

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -19,6 +19,43 @@ function formatDate(ts: number, lang: string): string {
 
 export type LinksFilter = "active" | "disabled" | "all";
 
+export type PaginationItem = number | "ellipsis";
+
+export function paginationItems(
+  currentPage: number,
+  totalPages: number,
+): PaginationItem[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  if (currentPage <= 4) {
+    return [1, 2, 3, 4, 5, "ellipsis", totalPages];
+  }
+
+  if (currentPage >= totalPages - 3) {
+    return [
+      1,
+      "ellipsis",
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+      totalPages,
+    ];
+  }
+
+  return [
+    1,
+    "ellipsis",
+    currentPage - 1,
+    currentPage,
+    currentPage + 1,
+    "ellipsis",
+    totalPages,
+  ];
+}
+
 type Props = {
   links: LinkWithSlugs[];
   sort: string;
@@ -274,13 +311,16 @@ export const LinksPage: FC<Props> = ({
                 >
                   <span class="icon icon-sm">chevron_left</span>
                 </a>
-                {Array.from({ length: totalPages }, (_, i) => i + 1).map(
-                  (p) => (
+                {paginationItems(currentPage, totalPages).map((item) =>
+                  item === "ellipsis" ? (
+                    <span class="page-ellipsis" aria-hidden="true">…</span>
+                  ) : (
                     <a
-                      class={`page-btn${p === currentPage ? " active" : ""}`}
-                      href={pageUrl(p)}
+                      class={`page-btn${item === currentPage ? " active" : ""}`}
+                      href={pageUrl(item)}
+                      aria-current={item === currentPage ? "page" : undefined}
                     >
-                      {p}
+                      {item}
                     </a>
                   ),
                 )}

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -476,13 +476,14 @@ select.form-input { appearance: none; -webkit-appearance: none; padding-right: 2
 .link-disabled { opacity: 0.5; }
 .disabled-badge { display: inline-flex; align-items: center; gap: 0.2rem; background: var(--color-danger); color: var(--color-danger-foreground); font-size: 0.65rem; font-weight: 700; padding: 0.15rem 0.5rem; border-radius: var(--radius-md); text-transform: uppercase; letter-spacing: 0.05em; }
 .link-date { font-size: 0.7rem; color: var(--color-text-muted); margin-top: 0.2rem; }
-.pagination { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-top: 1.4rem; padding: 0.75rem 0; }
+.pagination { display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 1rem; margin-top: 1.4rem; padding: 0.75rem 0; }
 .pagination-summary { font-size: 0.78rem; color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
-.pagination-pages { display: flex; gap: 0.25rem; }
+.pagination-pages { display: flex; align-items: center; gap: 0.25rem; max-width: 100%; }
 .page-btn { background: transparent; border: 2px solid var(--color-border); border-radius: var(--radius-md); color: var(--color-text-muted); font-family: var(--font-family-body); font-size: 0.8rem; font-weight: 600; padding: 0.3rem 0.6rem; cursor: pointer; transition: all 0.2s; min-width: 2rem; text-align: center; text-decoration: none; display: inline-flex; align-items: center; justify-content: center; }
 .page-btn:hover { border-color: var(--color-text-muted); color: var(--color-text); }
 .page-btn.active { border-color: var(--color-accent); color: var(--color-accent); }
 .page-btn:disabled, .page-btn.disabled { opacity: 0.3; cursor: default; pointer-events: none; }
+.page-ellipsis { display: inline-flex; align-items: center; justify-content: center; min-width: 1.5rem; color: var(--color-text-subtle); font-size: 0.8rem; }
 .per-page { display: flex; align-items: center; gap: 0.5rem; font-size: 0.78rem; color: var(--color-text-muted); }
 .per-page-label { font-size: 0.78rem; color: var(--color-text-muted); }
 .per-page-select { min-width: 4rem; }
@@ -840,7 +841,9 @@ select.form-input { appearance: none; -webkit-appearance: none; padding-right: 2
   .filter-chip { flex: 1; justify-content: center; }
   .settings-layout { flex-direction: column !important; }
   .settings-layout > div:last-child { max-width: 100% !important; }
-  .pagination { flex-wrap: wrap; gap: 0.5rem; justify-content: center; }
+  .pagination { gap: 0.5rem; justify-content: center; }
+  .pagination-pages { order: 3; width: 100%; justify-content: center; overflow-x: auto; }
+  .page-btn { padding-inline: 0.45rem; }
   .bundle-grid { grid-template-columns: 1fr; }
   .detail-analytics { grid-template-columns: 1fr; }
   .bundle-link-head { gap: 0.5rem; }


### PR DESCRIPTION
## Problem

The links pagination breaks the layout with a large number of links.

<img width="3456" height="370" alt="Screenshot From 2026-08-22 21-03-37" src="https://github.com/user-attachments/assets/e0901990-1414-405f-9b35-e487d17910a9" />


## Summary

- Render a compact seven-item pagination window with ellipses instead of one button per page.
- Preserve first, current, nearby, previous, next, and last-page navigation.
- Wrap the paginator and keep its controls contained at mobile widths.
- Mark the active page with aria-current and cover the pagination window with unit tests.

## Testing

- Targeted pagination and links-page tests: 17 passed.
- TypeScript check: passed.
- Playwright verification with 4,700 links at desktop and 375 px mobile widths: no horizontal page or control overflow.