### PR TITLE
Announce create_link idempotent contract and trailing-slash normalization

### DIFF
--- a/src/__tests__/handler/mcp.test.ts
+++ b/src/__tests__/handler/mcp.test.ts
@@ -686,4 +686,52 @@ describe("MCP tool descriptions", () => {
       await client.close();
     }
   });
+
+  // createLink() normalizes the URL and returns the existing row on a repeat
+  // call, so a caller never has to search before shortening. The description
+  // and the idempotent annotation both have to announce that, otherwise every
+  // agent re-discovers the contract by trial or by a wasted lookup.
+  it("create_link announces its idempotent upsert contract", async () => {
+    const agent = Object.create(ShrtnrMCP.prototype) as ShrtnrMCP;
+    agent.server = new McpServer({ name: "shrtnr", version: "test" });
+    await agent.init();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "test" });
+    await Promise.all([
+      client.connect(clientTransport),
+      agent.server.connect(serverTransport),
+    ]);
+
+    try {
+      const { tools } = await client.listTools();
+      const createLinkTool = tools.find((t) => t.name === "create_link");
+      expect(createLinkTool).toBeDefined();
+      expect(createLinkTool?.description).toMatch(/idempotent/i);
+      expect(createLinkTool?.description).toMatch(/trailing slash/i);
+      expect(createLinkTool?.description).toMatch(/no need to (search|look)/i);
+      expect(createLinkTool?.annotations?.idempotentHint).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+// ---- create_link trailing-slash normalization ----
+// The description promises that a trailing slash does not fork a second link.
+// This pins the behaviour behind that promise.
+
+describe("create_link URL normalization", () => {
+  it("treats a trailing-slash variant as the same destination", async () => {
+    const first = await createLink(env as never, { url: "https://slash.example/docs", created_by: "dennis@oddbit.id" });
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+
+    const second = await createLink(env as never, { url: "https://slash.example/docs/", created_by: "dennis@oddbit.id" });
+    expect(second.ok).toBe(true);
+    if (!second.ok) return;
+
+    expect(second.data.id).toBe(first.data.id);
+    expect(second.meta?.duplicate).toBe(true);
+  });
 });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -212,7 +212,7 @@ export class ShrtnrMCP extends McpAgent<Env, Record<string, never>, Props> {
       {
         title: "Create link",
         description:
-          "Shorten a URL and create a short link. If the destination URL already exists, the existing link is returned with `duplicate: true`, so there is no need to search for the URL first. Optional custom slugs are attached after creation; slugs already in use are reported in `slug_rejections` rather than failing the call.",
+          "Shorten a URL and create a short link. Idempotent, like an UPSERT: a repeat call with the same destination returns the existing link with `duplicate: true` instead of failing. It normalizes the trailing slash first, so `https://example.com/a/` and `https://example.com/a` resolve to one link. There is no need to look up or search for a URL before calling this. Optional custom slugs are attached after creation; slugs already in use are reported in `slug_rejections` rather than failing the call.",
         inputSchema: {
           url: z.string().url().describe("Destination URL to shorten"),
           label: z.string().optional().describe("Human-readable label for the link"),
@@ -225,7 +225,7 @@ export class ShrtnrMCP extends McpAgent<Env, Record<string, never>, Props> {
             ),
           expires_at: z.number().int().nonnegative().optional().describe("Unix timestamp when the link expires"),
         },
-        annotations: { title: "Create link", ...WRITE_NEW },
+        annotations: { title: "Create link", ...WRITE_IDEMPOTENT },
       },
       async ({ custom_slug, ...opts }) => {
         const result = await createLink(this.env, { ...opts, created_via: "mcp", created_by: this.identity });


### PR DESCRIPTION
## Summary

Clarifies the `create_link` tool's idempotent upsert behavior and URL normalization contract by updating its description, adding the `idempotentHint` annotation, and adding tests to pin the promised behavior.

## Changes

- **Tool description**: Expanded to explicitly state that `create_link` is idempotent (repeat calls return the existing link), normalizes trailing slashes so `https://example.com/a/` and `https://example.com/a` resolve to one link, and that callers need not search before calling.
- **Tool annotation**: Changed from `WRITE_NEW` to `WRITE_IDEMPOTENT` to signal the idempotent contract to MCP clients.
- **Test coverage**: Added test verifying the description and annotation announce the idempotent behavior, and a separate test suite pinning the trailing-slash normalization behavior (same destination with and without trailing slash returns the same link ID with `duplicate: true`).

## Implementation details

The tool already implemented idempotent upsert and trailing-slash normalization; this change surfaces those guarantees in the contract so agents discover the behavior from the tool definition rather than by trial.

https://claude.ai/code/session_01CkXynMbATGUrLX4iPVwZKV