### PR TITLE
Hide the links paginator when the result set fits one page

### DIFF
--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -224,4 +224,47 @@ describe("Links listing page", () => {
     const html = await res.text();
     expect(html).toMatch(/1\s*[–-]\s*1\s+of\s+30/);
   });
+
+  it("hides the paginator when a wider per_page fits every link on one page", async () => {
+    for (let i = 0; i < 30; i++) {
+      await LinkRepository.create(env.DB, {
+        url: `https://example${i}.com`,
+        slug: `s${i}`,
+      });
+    }
+    const res = await SELF.fetch(req("/_/admin/links?per_page=100"));
+    const html = await res.text();
+    // All 30 rows fit on page 1, so there is nothing to page through.
+    expect(html).not.toContain('class="pagination"');
+    expect(html).not.toMatch(/class="page-btn/);
+  });
+
+  it("hides the paginator when a filter narrows the result set to one page", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    for (let i = 0; i < 30; i++) {
+      await LinkRepository.create(env.DB, {
+        url: `https://example${i}.com`,
+        slug: `s${i}`,
+        expiresAt: i < 2 ? now - 3600 : null,
+      });
+    }
+    const res = await SELF.fetch(req("/_/admin/links?filter=disabled"));
+    const html = await res.text();
+    // Only 2 of the 30 links are expired; the unfiltered count must not decide this.
+    expect(html).not.toContain('class="pagination"');
+    expect(html).not.toMatch(/class="page-btn/);
+  });
+
+  it("still renders the paginator when the result set spans more than one page", async () => {
+    for (let i = 0; i < 30; i++) {
+      await LinkRepository.create(env.DB, {
+        url: `https://example${i}.com`,
+        slug: `s${i}`,
+      });
+    }
+    const res = await SELF.fetch(req("/_/admin/links"));
+    const html = await res.text();
+    expect(html).toContain('class="pagination"');
+    expect(html).toMatch(/class="page-btn[^"]*"[^>]*>2</);
+  });
 });

--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -225,7 +225,7 @@ describe("Links listing page", () => {
     expect(html).toMatch(/1\s*[–-]\s*1\s+of\s+30/);
   });
 
-  it("hides the paginator when a wider per_page fits every link on one page", async () => {
+  it("hides the page buttons when a wider per_page fits every link on one page", async () => {
     for (let i = 0; i < 30; i++) {
       await LinkRepository.create(env.DB, {
         url: `https://example${i}.com`,
@@ -233,13 +233,19 @@ describe("Links listing page", () => {
       });
     }
     const res = await SELF.fetch(req("/_/admin/links?per_page=100"));
+    expect(res.status).toBe(200);
     const html = await res.text();
-    // All 30 rows fit on page 1, so there is nothing to page through.
-    expect(html).not.toContain('class="pagination"');
+    // All 30 rows land on page 1, so there is nothing to page through.
+    expect(html.match(/class="col-short-chip-slug"/g)).toHaveLength(30);
+    expect(html).not.toContain('class="pagination-pages"');
     expect(html).not.toMatch(/class="page-btn/);
+    // The summary and the per-page selector survive: they are the only way back to 25.
+    expect(html).toContain('class="pagination"');
+    expect(html).toContain('class="pagination-summary"');
+    expect(html).toContain("per-page-select");
   });
 
-  it("hides the paginator when a filter narrows the result set to one page", async () => {
+  it("hides the page buttons when a filter narrows the result set to one page", async () => {
     const now = Math.floor(Date.now() / 1000);
     for (let i = 0; i < 30; i++) {
       await LinkRepository.create(env.DB, {
@@ -249,13 +255,20 @@ describe("Links listing page", () => {
       });
     }
     const res = await SELF.fetch(req("/_/admin/links?filter=disabled"));
+    expect(res.status).toBe(200);
     const html = await res.text();
-    // Only 2 of the 30 links are expired; the unfiltered count must not decide this.
-    expect(html).not.toContain('class="pagination"');
+    // Only s0 and s1 are expired; the unfiltered count must not decide this.
+    expect(html.match(/class="col-short-chip-slug"/g)).toHaveLength(2);
+    expect(html).toContain(">s0<");
+    expect(html).toContain(">s1<");
+    expect(html).not.toContain(">s2<");
+    expect(html).not.toContain('class="pagination-pages"');
     expect(html).not.toMatch(/class="page-btn/);
+    expect(html).toContain('class="pagination-summary"');
+    expect(html).toContain("per-page-select");
   });
 
-  it("still renders the paginator when the result set spans more than one page", async () => {
+  it("still renders the page buttons when the result set spans more than one page", async () => {
     for (let i = 0; i < 30; i++) {
       await LinkRepository.create(env.DB, {
         url: `https://example${i}.com`,
@@ -263,8 +276,27 @@ describe("Links listing page", () => {
       });
     }
     const res = await SELF.fetch(req("/_/admin/links"));
+    expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain('class="pagination"');
+    expect(html).toContain('class="pagination-pages"');
     expect(html).toMatch(/class="page-btn[^"]*"[^>]*>2</);
+    expect(html).toContain("per-page-select");
   });
+
+  it("keeps the per-page selector reachable after widening per_page", async () => {
+    for (let i = 0; i < 30; i++) {
+      await LinkRepository.create(env.DB, {
+        url: `https://example${i}.com`,
+        slug: `s${i}`,
+      });
+    }
+    const res = await SELF.fetch(req("/_/admin/links?per_page=50"));
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Every in-page link re-emits per_page, so the selector is the only route back to 25.
+    expect(html).toContain("per-page-select");
+    expect(html).toContain("per_page=25");
+  });
+
 });

--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -298,5 +298,4 @@ describe("Links listing page", () => {
     expect(html).toContain("per-page-select");
     expect(html).toContain("per_page=25");
   });
-
 });

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -300,7 +300,7 @@ export const LinksPage: FC<Props> = ({
             </div>
           </div>
 
-          {(totalPages > 1 || links.length > 25) && (
+          {totalPages > 1 && (
             <div class="pagination">
               <div class="pagination-summary">
                 {t("links.pageSummary", {

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -300,15 +300,15 @@ export const LinksPage: FC<Props> = ({
             </div>
           </div>
 
-          {totalPages > 1 && (
-            <div class="pagination">
-              <div class="pagination-summary">
-                {t("links.pageSummary", {
-                  from: sorted.length === 0 ? 0 : start + 1,
-                  to: Math.min(start + perPage, sorted.length),
-                  total: sorted.length,
-                })}
-              </div>
+          <div class="pagination">
+            <div class="pagination-summary">
+              {t("links.pageSummary", {
+                from: start + 1,
+                to: Math.min(start + perPage, sorted.length),
+                total: sorted.length,
+              })}
+            </div>
+            {totalPages > 1 && (
               <div class="pagination-pages">
                 <a
                   class={`page-btn${currentPage <= 1 ? " disabled" : ""}`}
@@ -340,25 +340,25 @@ export const LinksPage: FC<Props> = ({
                   <span class="icon icon-sm">chevron_right</span>
                 </a>
               </div>
-              <div class="per-page">
-                <span class="per-page-label">{t("links.show")}</span>
-                <div class="form-select per-page-select">
-                  <select
-                    class="form-input form-input-sm"
-                    onchange="location.href=this.value"
-                    aria-label={t("links.perPageAria")}
-                  >
-                    {[25, 50, 100].map((n) => (
-                      <option value={perPageUrl(n)} selected={perPage === n}>
-                        {n}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <span class="per-page-label">{t("links.perPage")}</span>
+            )}
+            <div class="per-page">
+              <span class="per-page-label">{t("links.show")}</span>
+              <div class="form-select per-page-select">
+                <select
+                  class="form-input form-input-sm"
+                  onchange="location.href=this.value"
+                  aria-label={t("links.perPageAria")}
+                >
+                  {[25, 50, 100].map((n) => (
+                    <option value={perPageUrl(n)} selected={perPage === n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
               </div>
+              <span class="per-page-label">{t("links.perPage")}</span>
             </div>
-          )}
+          </div>
         </>
       )}
     </>


### PR DESCRIPTION
Closes [#44](https://github.com/oddbit/shrtnr/issues/44).

## The bug

`src/pages/links.tsx` guarded the paginator with `totalPages > 1 || links.length > 25`. That condition tests `links`, the unfiltered set, instead of `sorted`, the set pagination actually walks. It also hardcodes `25` instead of reading `perPage`.

Both reproductions from the issue render a dead control: a lone `1` button with both chevrons disabled.

- `per_page=100` over 30 links. `totalPages` is 1, but `30 > 25` renders the paginator.
- `filter=disabled` over 200 links of which 2 have expired. `sorted.length` is 2 and `totalPages` is 1, yet `200 > 25` renders it.

## The fix

Split the gate. `.pagination` renders whenever the table renders. Only `.pagination-pages`, the chevrons and page numbers, depends on `totalPages > 1`.

An earlier revision of this PR gated the whole `.pagination` block on `totalPages > 1`. That removed the dead control, but it also hid the result summary and the 25/50/100 per-page selector, which stranded the user. `buildUrl` re-emits `per_page` into every sort link and filter chip (`src/pages/links.tsx:116`) and the range picker preserves it (`:145`). After picking 50 rows over 30 links, `totalPages` fell to 1 and no in-page control set it back to 25. `per_page` lives only in the URL (`src/index.tsx:235`), so the only way back was leaving the links page entirely.

Issue #44 asked for the dead control to go, not for the summary and the selector to go with it.

Also collapsed the page-summary ternary. `totalPages > 1` implies `sorted.length > perPage >= 1`, so the `sorted.length === 0` branch was already unreachable once the `links.length > 25` escape hatch went away.

## Tests

Four cases in `src/__tests__/page/links-page.test.ts`, one per reproduction plus two guards:

- `per_page=100` with 30 links renders 30 rows and no page buttons, and keeps the summary and selector.
- `filter=disabled` with 2 of 30 links expired renders `s0` and `s1` only, no page buttons, and keeps the selector.
- 30 links at the default page size still renders the page buttons, page `2` included.
- `per_page=50` over 30 links still offers the `per_page=25` route back.

Every case asserts a 200 status and counts rendered rows, so none can pass on an empty state or a 500.

Verified three ways:

- Three of the four fail against the whole-block gate: both reproduction cases plus the `per_page=50` route back. The multi-page case exercises `totalPages > 1`, where either gate shape renders the block, so it passes against both by design.
- The two reproduction cases also fail against `main`, so they still cover the original bug.
- Full suite: 1153 tests across 77 files, all passing. `tsc --noEmit` clean.

## Follow-ups

Reviewing this PR surfaced five pre-existing bugs in `src/pages/links.tsx` that it does not touch. Filed separately to keep this change to one concern: #51 (empty-state copy ignores the active filter), #52 (zero-match search reads as an empty catalog), #53 (disabled chevrons stay keyboard-activatable), #54 (chevrons have no accessible name, page group has no landmark).

