### PR TITLE
Window the links listing in SQL instead of loading the catalog

### DIFF
--- a/migrations/0007_links_created_at_index.sql
+++ b/migrations/0007_links_created_at_index.sql
@@ -1,0 +1,10 @@
+-- The admin links listing windows in SQL: it filters, orders by
+-- `created_at DESC, id DESC`, then applies LIMIT/OFFSET. With no index on
+-- those columns SQLite scans links and builds a temp B-tree to sort the whole
+-- table, so rendering 25 rows costs O(catalog log catalog) on every request
+-- and the windowing saves only the JS-side assembly.
+--
+-- The index covers the order the listing asks for, so the planner walks it and
+-- stops after `limit + offset` rows. `recent()` and the dashboard panels use
+-- the same ordering and get the same walk.
+CREATE INDEX idx_links_created_at ON links(created_at DESC, id DESC);

--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -225,3 +225,91 @@ describe("Links listing page", () => {
     expect(html).toMatch(/1\s*[–-]\s*1\s+of\s+30/);
   });
 });
+
+describe("Links listing page windowing", () => {
+  async function seed(count: number): Promise<void> {
+    for (let i = 0; i < count; i++) {
+      await LinkRepository.create(env.DB, { url: `https://example${i}.com`, slug: `s${i}` });
+    }
+  }
+
+  function rowCount(html: string): number {
+    return [...html.matchAll(/class="col-short-chip-slug">/g)].length;
+  }
+
+  it("renders only the requested window of rows, not the whole catalog", async () => {
+    await seed(60);
+    const res = await SELF.fetch(req("/_/admin/links?per_page=25"));
+    const html = await res.text();
+    expect(rowCount(html)).toBe(25);
+    expect(html).toMatch(/1\s*[–-]\s*25\s+of\s+60/);
+  });
+
+  it("serves the next window on page 2 with no overlap", async () => {
+    await seed(30);
+    const first = await (await SELF.fetch(req("/_/admin/links?per_page=25&page=1"))).text();
+    const second = await (await SELF.fetch(req("/_/admin/links?per_page=25&page=2"))).text();
+    expect(rowCount(second)).toBe(5);
+    expect(second).toMatch(/26\s*[–-]\s*30\s+of\s+30/);
+    const slugsOn = (html: string) =>
+      [...html.matchAll(/class="col-short-chip-slug">([^<]+)</g)].map((m) => m[1]);
+    const firstSlugs = new Set(slugsOn(first));
+    expect(slugsOn(second).some((s) => firstSlugs.has(s))).toBe(false);
+  });
+
+  it("caps per_page so a crafted query cannot pull the catalog into one page", async () => {
+    await seed(120);
+    const res = await SELF.fetch(req("/_/admin/links?per_page=100000"));
+    const html = await res.text();
+    expect(rowCount(html)).toBe(100);
+    expect(html).toMatch(/1\s*[–-]\s*100\s+of\s+120/);
+  });
+
+  it("sorts popular across the whole catalog, not within the rendered page", async () => {
+    await seed(30);
+    // s0 is the oldest link, so recent order puts it on the last page. Its
+    // click lead must still float it to the top of page 1 under popular sort.
+    const now = Math.floor(Date.now() / 1000);
+    const insert = env.DB.prepare(
+      "INSERT INTO clicks (slug, clicked_at, link_mode, is_bot, is_self_referrer) VALUES (?, ?, 'link', 0, 0)",
+    );
+    await insert.bind("s0", now - 60).run();
+    await insert.bind("s0", now - 61).run();
+
+    const html = await (await SELF.fetch(req("/_/admin/links?sort=popular&per_page=25"))).text();
+    const slugs = [...html.matchAll(/class="col-short-chip-slug">([^<]+)</g)].map((m) => m[1]);
+    expect(slugs[0]).toBe("s0");
+  });
+
+  it("counts and pages the filtered set for the disabled filter", async () => {
+    for (let i = 0; i < 6; i++) {
+      const link = await LinkRepository.create(env.DB, { url: `https://e${i}.com`, slug: `d${i}` });
+      if (i % 2 === 0) {
+        await LinkRepository.update(env.DB, link.id, { expires_at: Math.floor(Date.now() / 1000) - 10 });
+      }
+    }
+    const html = await (await SELF.fetch(req("/_/admin/links?filter=disabled&per_page=2"))).text();
+    expect(html).toMatch(/1\s*[–-]\s*2\s+of\s+3/);
+    expect(rowCount(html)).toBe(2);
+  });
+
+  it("windows search results and counts every match", async () => {
+    await seed(30);
+    const html = await (await SELF.fetch(req("/_/admin/links?search=example&per_page=10&page=2"))).text();
+    expect(html).toContain("30 matching links");
+    expect(rowCount(html)).toBe(10);
+    expect(html).toMatch(/11\s*[–-]\s*20\s+of\s+30/);
+  });
+
+  it("keeps the all-disabled empty state when the active filter hides everything", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
+    await LinkRepository.update(env.DB, link.id, { expires_at: Math.floor(Date.now() / 1000) - 10 });
+    const html = await (await SELF.fetch(req("/_/admin/links", { headers: { Cookie: "lang=en" } }))).text();
+    expect(html).toContain("All links are disabled");
+  });
+
+  it("shows the first-run empty state when there are no links at all", async () => {
+    const html = await (await SELF.fetch(req("/_/admin/links", { headers: { Cookie: "lang=en" } }))).text();
+    expect(html).toContain("No links yet");
+  });
+});

--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -324,6 +324,14 @@ describe("Links listing page", () => {
     expect(html).not.toMatch(/class="page-btn[^"]*"[^>]*>6</);
   });
 
+  it("clamps an unparseable page param onto the first page", async () => {
+    for (let i = 0; i < 30; i++) {
+      await LinkRepository.create(env.DB, { url: `https://example${i}.com`, slug: `s${i}` });
+    }
+    const html = await (await SELF.fetch(req("/_/admin/links?page=abc"))).text();
+    expect(html).toMatch(/1\s*[–-]\s*25\s+of\s+30/);
+  });
+
   it("clamps a negative per_page param instead of an inverted slice range", async () => {
     for (let i = 0; i < 30; i++) {
       await LinkRepository.create(env.DB, {

--- a/src/__tests__/page/links-page.test.ts
+++ b/src/__tests__/page/links-page.test.ts
@@ -10,6 +10,15 @@ function req(path: string, init?: RequestInit): Request {
   return new Request(`https://shrtnr.test${path}`, init);
 }
 
+/**
+ * The rendered empty state, or "" when the page has rows. The layout embeds
+ * every translation string in the admin client script, so a page-wide match
+ * on empty copy hits that blob instead of the markup.
+ */
+function emptyState(html: string): string {
+  return html.match(/<div class="empty-state">.*?<\/div>/s)?.[0] ?? "";
+}
+
 beforeAll(applyMigrations);
 beforeEach(resetData);
 
@@ -487,5 +496,38 @@ describe("Links listing page windowing", () => {
   it("shows the first-run empty state when there are no links at all", async () => {
     const html = await (await SELF.fetch(req("/_/admin/links", { headers: { Cookie: "lang=en" } }))).text();
     expect(html).toContain("No links yet");
+  });
+
+  it("does not claim every link is disabled when the disabled filter matched nothing", async () => {
+    for (const slug of ["one", "two", "three"]) {
+      await LinkRepository.create(env.DB, { url: `https://example.com/${slug}`, slug });
+    }
+    const html = await (
+      await SELF.fetch(req("/_/admin/links?filter=disabled", { headers: { Cookie: "lang=en" } }))
+    ).text();
+
+    expect(emptyState(html)).not.toContain("All links are disabled");
+    expect(emptyState(html)).toContain("No links match");
+  });
+
+  it("points the all-disabled empty state at the filter that shows them", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
+    await LinkRepository.update(env.DB, link.id, { expires_at: Math.floor(Date.now() / 1000) - 10 });
+    const html = await (await SELF.fetch(req("/_/admin/links", { headers: { Cookie: "lang=en" } }))).text();
+
+    // The filter chips replaced the "Show disabled" toggle the copy named.
+    expect(html).not.toContain("Show disabled");
+  });
+
+  it("does not print a row count above an empty state", async () => {
+    for (const slug of ["one", "two", "three"]) {
+      await LinkRepository.create(env.DB, { url: `https://example.com/${slug}`, slug });
+    }
+    const html = await (
+      await SELF.fetch(req("/_/admin/links?search=xyzzy-nothing", { headers: { Cookie: "lang=en" } }))
+    ).text();
+
+    expect(emptyState(html)).toContain("No links match");
+    expect(emptyState(html)).not.toContain("No links yet");
   });
 });

--- a/src/__tests__/repository/link-page-plan.test.ts
+++ b/src/__tests__/repository/link-page-plan.test.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { applyMigrations, resetData } from "../setup";
+import { LinkRepository } from "../../db";
+
+beforeAll(applyMigrations);
+beforeEach(resetData);
+
+/** The planner's steps for a statement, one string per row. */
+async function plan(sql: string, ...binds: unknown[]): Promise<string[]> {
+  const rows = await env.DB.prepare(`EXPLAIN QUERY PLAN ${sql}`)
+    .bind(...binds)
+    .all<{ detail: string }>();
+  return (rows.results ?? []).map((r) => r.detail);
+}
+
+describe("links listing query plans", () => {
+  it("indexes the order the listing pages by", async () => {
+    const rows = await env.DB.prepare("PRAGMA index_list(links)").all<{ name: string }>();
+    expect((rows.results ?? []).map((r) => r.name)).toContain("idx_links_created_at");
+  });
+
+  it("walks the index for the recent window instead of sorting the catalog", async () => {
+    for (let i = 0; i < 40; i++) {
+      await LinkRepository.create(env.DB, { url: `https://example${i}.com`, slug: `p${i}` });
+    }
+    await env.DB.exec("ANALYZE");
+
+    const steps = await plan(
+      "SELECT l.* FROM links l ORDER BY l.created_at DESC, l.id DESC LIMIT ? OFFSET ?",
+      25,
+      0,
+    );
+
+    // A temp B-tree here means the planner materialized and sorted every row
+    // before taking 25 of them, which is the cost the index exists to remove.
+    expect(steps.join(" | ")).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    expect(steps.join(" | ")).toContain("idx_links_created_at");
+  });
+});

--- a/src/__tests__/repository/link-page.test.ts
+++ b/src/__tests__/repository/link-page.test.ts
@@ -23,7 +23,12 @@ async function click(slug: string, at: number): Promise<void> {
   ).bind(slug, at).run();
 }
 
-/** Counts prepare() calls so a test can assert cost does not scale with catalog size. */
+/**
+ * Counts the statements a call issues so a test can pin the cost of a page
+ * render. Traps exec() alongside prepare(): batch() composes already-prepared
+ * statements and so is counted through prepare, but exec() takes raw SQL and
+ * would otherwise slip past the count entirely.
+ */
 function countingDb(counter: { n: number }): D1Database {
   return new Proxy(env.DB, {
     get(target, prop, receiver) {
@@ -31,6 +36,12 @@ function countingDb(counter: { n: number }): D1Database {
         return (sql: string) => {
           counter.n++;
           return (target as unknown as D1Database).prepare(sql);
+        };
+      }
+      if (prop === "exec") {
+        return (sql: string) => {
+          counter.n++;
+          return (target as unknown as D1Database).exec(sql);
         };
       }
       const value = Reflect.get(target, prop, receiver);
@@ -72,7 +83,7 @@ describe("LinkRepository.page windowing", () => {
     expect((await LinkRepository.page(env.DB, { limit: -3 })).links).toEqual([]);
   });
 
-  it("costs the same number of queries at 5 links as at 60", async () => {
+  it("costs three statements at 5 links and the same three at 60", async () => {
     await seed(5, "a");
     const small = { n: 0 };
     await LinkRepository.page(countingDb(small), { limit: 25 });
@@ -81,7 +92,11 @@ describe("LinkRepository.page windowing", () => {
     const large = { n: 0 };
     const result = await LinkRepository.page(countingDb(large), { limit: 25 });
 
-    expect(large.n).toBe(small.n);
+    // Pin the absolute count, not just the equality: a regression to thirty
+    // statements per render is equally flat across catalog sizes and would
+    // satisfy an equality assertion on its own.
+    expect(small.n).toBe(3);
+    expect(large.n).toBe(3);
     expect(result.links).toHaveLength(25);
     expect(result.total).toBe(60);
   });

--- a/src/__tests__/repository/link-page.test.ts
+++ b/src/__tests__/repository/link-page.test.ts
@@ -24,23 +24,23 @@ async function click(slug: string, at: number): Promise<void> {
 }
 
 /**
- * Counts the statements a call issues so a test can pin the cost of a page
- * render. Traps exec() alongside prepare(): batch() composes already-prepared
- * statements and so is counted through prepare, but exec() takes raw SQL and
- * would otherwise slip past the count entirely.
+ * Records the SQL of every statement a call issues, so a test can pin both the
+ * cost of a page render and the shape of what it sends. Traps exec() alongside
+ * prepare(): batch() composes already-prepared statements and so is recorded
+ * through prepare, but exec() takes raw SQL and would slip past entirely.
  */
-function countingDb(counter: { n: number }): D1Database {
+function spyDb(log: string[]): D1Database {
   return new Proxy(env.DB, {
     get(target, prop, receiver) {
       if (prop === "prepare") {
         return (sql: string) => {
-          counter.n++;
+          log.push(sql);
           return (target as unknown as D1Database).prepare(sql);
         };
       }
       if (prop === "exec") {
         return (sql: string) => {
-          counter.n++;
+          log.push(sql);
           return (target as unknown as D1Database).exec(sql);
         };
       }
@@ -85,20 +85,46 @@ describe("LinkRepository.page windowing", () => {
 
   it("costs three statements at 5 links and the same three at 60", async () => {
     await seed(5, "a");
-    const small = { n: 0 };
-    await LinkRepository.page(countingDb(small), { limit: 25 });
+    const small: string[] = [];
+    await LinkRepository.page(spyDb(small), { limit: 25 });
 
     await seed(55, "b");
-    const large = { n: 0 };
-    const result = await LinkRepository.page(countingDb(large), { limit: 25 });
+    const large: string[] = [];
+    const result = await LinkRepository.page(spyDb(large), { limit: 25 });
 
     // Pin the absolute count, not just the equality: a regression to thirty
     // statements per render is equally flat across catalog sizes and would
     // satisfy an equality assertion on its own.
-    expect(small.n).toBe(3);
-    expect(large.n).toBe(3);
+    expect(small).toHaveLength(3);
+    expect(large).toHaveLength(3);
     expect(result.links).toHaveLength(25);
     expect(result.total).toBe(60);
+  });
+
+  it("computes the filtered, sorted window exactly once per render", async () => {
+    await seed(30);
+    const log: string[] = [];
+    await LinkRepository.page(spyDb(log), { limit: 5, offset: 5, sort: "popular" });
+
+    // Under sort=popular the window's ORDER BY is a correlated COUNT over
+    // clicks joined to slugs, so re-running it to fetch the slugs doubles the
+    // per-row aggregates. Only the link query may carry the window, and only
+    // it may carry the link-level aggregate the ordering rests on. The slug
+    // query has its own per-slug click_count, hence the narrower match.
+    expect(log.filter((sql) => sql.includes("LIMIT ? OFFSET ?"))).toHaveLength(1);
+    expect(log.filter((sql) => sql.includes("JOIN slugs cs"))).toHaveLength(1);
+  });
+
+  it("binds the served ids to fetch slugs, staying inside the D1 parameter cap", async () => {
+    await seed(3);
+    const log: string[] = [];
+    const result = await LinkRepository.page(spyDb(log), { limit: 2 });
+
+    const slugQuery = log.find((sql) => sql.includes("FROM slugs s WHERE s.link_id IN"));
+    expect(slugQuery).toBeDefined();
+    expect(slugQuery).toContain("IN (?,?)");
+    expect(result.links).toHaveLength(2);
+    expect(result.links.every((l) => l.slugs.length === 1)).toBe(true);
   });
 
   it("attaches every slug of the windowed links and no others", async () => {

--- a/src/__tests__/repository/link-page.test.ts
+++ b/src/__tests__/repository/link-page.test.ts
@@ -3,7 +3,7 @@
 
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { env } from "cloudflare:test";
-import { applyMigrations, resetData } from "../setup";
+import { applyMigrations, resetData, spyDb } from "../setup";
 import { LinkRepository, SlugRepository } from "../../db";
 
 beforeAll(applyMigrations);
@@ -21,33 +21,6 @@ async function click(slug: string, at: number): Promise<void> {
   await env.DB.prepare(
     "INSERT INTO clicks (slug, clicked_at, link_mode, is_bot, is_self_referrer) VALUES (?, ?, 'link', 0, 0)",
   ).bind(slug, at).run();
-}
-
-/**
- * Records the SQL of every statement a call issues, so a test can pin both the
- * cost of a page render and the shape of what it sends. Traps exec() alongside
- * prepare(): batch() composes already-prepared statements and so is recorded
- * through prepare, but exec() takes raw SQL and would slip past entirely.
- */
-function spyDb(log: string[]): D1Database {
-  return new Proxy(env.DB, {
-    get(target, prop, receiver) {
-      if (prop === "prepare") {
-        return (sql: string) => {
-          log.push(sql);
-          return (target as unknown as D1Database).prepare(sql);
-        };
-      }
-      if (prop === "exec") {
-        return (sql: string) => {
-          log.push(sql);
-          return (target as unknown as D1Database).exec(sql);
-        };
-      }
-      const value = Reflect.get(target, prop, receiver);
-      return typeof value === "function" ? value.bind(target) : value;
-    },
-  }) as unknown as D1Database;
 }
 
 describe("LinkRepository.page windowing", () => {

--- a/src/__tests__/repository/link-page.test.ts
+++ b/src/__tests__/repository/link-page.test.ts
@@ -1,0 +1,295 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { applyMigrations, resetData } from "../setup";
+import { LinkRepository, SlugRepository } from "../../db";
+
+beforeAll(applyMigrations);
+beforeEach(resetData);
+
+const NOW = Math.floor(Date.now() / 1000);
+
+async function seed(count: number, prefix = "s"): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await LinkRepository.create(env.DB, { url: `https://example${i}.com`, slug: `${prefix}${i}` });
+  }
+}
+
+async function click(slug: string, at: number): Promise<void> {
+  await env.DB.prepare(
+    "INSERT INTO clicks (slug, clicked_at, link_mode, is_bot, is_self_referrer) VALUES (?, ?, 'link', 0, 0)",
+  ).bind(slug, at).run();
+}
+
+/** Counts prepare() calls so a test can assert cost does not scale with catalog size. */
+function countingDb(counter: { n: number }): D1Database {
+  return new Proxy(env.DB, {
+    get(target, prop, receiver) {
+      if (prop === "prepare") {
+        return (sql: string) => {
+          counter.n++;
+          return (target as unknown as D1Database).prepare(sql);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as unknown as D1Database;
+}
+
+describe("LinkRepository.page windowing", () => {
+  it("returns at most `limit` rows and the unwindowed total", async () => {
+    await seed(30);
+    const result = await LinkRepository.page(env.DB, { limit: 25 });
+    expect(result.links).toHaveLength(25);
+    expect(result.total).toBe(30);
+    expect(result.offset).toBe(0);
+  });
+
+  it("walks disjoint windows across pages", async () => {
+    await seed(30);
+    const first = await LinkRepository.page(env.DB, { limit: 25, offset: 0 });
+    const second = await LinkRepository.page(env.DB, { limit: 25, offset: 25 });
+    expect(second.links).toHaveLength(5);
+    expect(second.offset).toBe(25);
+    const firstIds = new Set(first.links.map((l) => l.id));
+    expect(second.links.some((l) => firstIds.has(l.id))).toBe(false);
+  });
+
+  it("clamps an offset past the end to the last populated window", async () => {
+    await seed(30);
+    const result = await LinkRepository.page(env.DB, { limit: 25, offset: 500 });
+    expect(result.offset).toBe(25);
+    expect(result.links).toHaveLength(5);
+    expect(result.total).toBe(30);
+  });
+
+  it("returns an empty page for a non-positive limit rather than the whole table", async () => {
+    await seed(5);
+    expect((await LinkRepository.page(env.DB, { limit: 0 })).links).toEqual([]);
+    expect((await LinkRepository.page(env.DB, { limit: -3 })).links).toEqual([]);
+  });
+
+  it("costs the same number of queries at 5 links as at 60", async () => {
+    await seed(5, "a");
+    const small = { n: 0 };
+    await LinkRepository.page(countingDb(small), { limit: 25 });
+
+    await seed(55, "b");
+    const large = { n: 0 };
+    const result = await LinkRepository.page(countingDb(large), { limit: 25 });
+
+    expect(large.n).toBe(small.n);
+    expect(result.links).toHaveLength(25);
+    expect(result.total).toBe(60);
+  });
+
+  it("attaches every slug of the windowed links and no others", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
+    await SlugRepository.addCustom(env.DB, link.id, "alias-one");
+    await SlugRepository.addCustom(env.DB, link.id, "alias-two");
+    const other = await LinkRepository.create(env.DB, { url: "https://other.com", slug: "xyz" });
+
+    const result = await LinkRepository.page(env.DB, { limit: 1 });
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].id).toBe(other.id);
+    expect(result.links[0].slugs.map((s) => s.slug)).toEqual(["xyz"]);
+
+    const secondPage = await LinkRepository.page(env.DB, { limit: 1, offset: 1 });
+    expect(secondPage.links[0].slugs.map((s) => s.slug).sort()).toEqual(["abc", "alias-one", "alias-two"]);
+  });
+});
+
+describe("LinkRepository.page ordering", () => {
+  it("orders by created_at descending with an id tie-break", async () => {
+    for (let i = 0; i < 4; i++) {
+      await LinkRepository.create(env.DB, { url: `https://example${i}.com`, slug: `s${i}` });
+    }
+    // Same second for every row: the id tie-break decides, so a window is stable.
+    await env.DB.prepare("UPDATE links SET created_at = ?").bind(NOW).run();
+    const first = await LinkRepository.page(env.DB, { limit: 2 });
+    const second = await LinkRepository.page(env.DB, { limit: 2, offset: 2 });
+    const ids = [...first.links, ...second.links].map((l) => l.id);
+    expect(ids).toEqual([...ids].sort((a, b) => b - a));
+  });
+
+  it("sorts popular by total clicks across the whole catalog, not just the first window", async () => {
+    await seed(6);
+    // The oldest link (s0) is the most clicked, so recent order would bury it
+    // on the last page while popular order must surface it first.
+    await click("s0", NOW - 60);
+    await click("s0", NOW - 61);
+    await click("s3", NOW - 62);
+
+    const popular = await LinkRepository.page(env.DB, { limit: 2, sort: "popular" });
+    expect(popular.links[0].slugs[0].slug).toBe("s0");
+    expect(popular.links[0].total_clicks).toBe(2);
+    expect(popular.links[1].slugs[0].slug).toBe("s3");
+  });
+
+  it("scopes popular ordering to the requested click window", async () => {
+    await seed(3);
+    // s0 dominates lifetime, s2 dominates the last 7 days.
+    await click("s0", NOW - 60 * 86400);
+    await click("s0", NOW - 61 * 86400);
+    await click("s2", NOW - 3600);
+
+    const lifetime = await LinkRepository.page(env.DB, { limit: 1, sort: "popular" });
+    expect(lifetime.links[0].slugs[0].slug).toBe("s0");
+
+    const week = await LinkRepository.page(
+      env.DB,
+      { limit: 1, sort: "popular" },
+      { sinceTs: NOW - 7 * 86400 },
+    );
+    expect(week.links[0].slugs[0].slug).toBe("s2");
+    expect(week.links[0].total_clicks).toBe(1);
+  });
+
+  it("excludes bot clicks from popular ordering when filtered", async () => {
+    await seed(2);
+    await env.DB.prepare(
+      "INSERT INTO clicks (slug, clicked_at, link_mode, is_bot, is_self_referrer) VALUES (?, ?, 'link', 1, 0)",
+    ).bind("s0", NOW - 60).run();
+    await env.DB.prepare(
+      "INSERT INTO clicks (slug, clicked_at, link_mode, is_bot, is_self_referrer) VALUES (?, ?, 'link', 1, 0)",
+    ).bind("s0", NOW - 61).run();
+    await click("s1", NOW - 62);
+
+    const filtered = await LinkRepository.page(
+      env.DB,
+      { limit: 1, sort: "popular" },
+      { filters: { excludeBots: true } },
+    );
+    expect(filtered.links[0].slugs[0].slug).toBe("s1");
+    expect(filtered.links[0].total_clicks).toBe(1);
+  });
+});
+
+describe("LinkRepository.page status filter", () => {
+  it("keeps only unexpired links for status active", async () => {
+    const live = await LinkRepository.create(env.DB, { url: "https://live.com", slug: "live" });
+    const expired = await LinkRepository.create(env.DB, { url: "https://dead.com", slug: "dead" });
+    await LinkRepository.update(env.DB, expired.id, { expires_at: NOW - 10 });
+
+    const result = await LinkRepository.page(env.DB, { limit: 25, status: "active", now: NOW });
+    expect(result.total).toBe(1);
+    expect(result.links.map((l) => l.id)).toEqual([live.id]);
+  });
+
+  it("keeps only expired links for status disabled", async () => {
+    await LinkRepository.create(env.DB, { url: "https://live.com", slug: "live" });
+    const expired = await LinkRepository.create(env.DB, { url: "https://dead.com", slug: "dead" });
+    await LinkRepository.update(env.DB, expired.id, { expires_at: NOW - 10 });
+
+    const result = await LinkRepository.page(env.DB, { limit: 25, status: "disabled", now: NOW });
+    expect(result.total).toBe(1);
+    expect(result.links.map((l) => l.id)).toEqual([expired.id]);
+  });
+
+  it("treats a future expiry as active", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://live.com", slug: "live" });
+    await LinkRepository.update(env.DB, link.id, { expires_at: NOW + 3600 });
+    expect((await LinkRepository.page(env.DB, { limit: 25, status: "active", now: NOW })).total).toBe(1);
+    expect((await LinkRepository.page(env.DB, { limit: 25, status: "disabled", now: NOW })).total).toBe(0);
+  });
+
+  it("counts both for status all", async () => {
+    await LinkRepository.create(env.DB, { url: "https://live.com", slug: "live" });
+    const expired = await LinkRepository.create(env.DB, { url: "https://dead.com", slug: "dead" });
+    await LinkRepository.update(env.DB, expired.id, { expires_at: NOW - 10 });
+    expect((await LinkRepository.page(env.DB, { limit: 25, status: "all", now: NOW })).total).toBe(2);
+  });
+
+  it("pages the filtered set, so the window never mixes in excluded rows", async () => {
+    for (let i = 0; i < 6; i++) {
+      const link = await LinkRepository.create(env.DB, { url: `https://e${i}.com`, slug: `s${i}` });
+      if (i % 2 === 0) await LinkRepository.update(env.DB, link.id, { expires_at: NOW - 10 });
+    }
+    const result = await LinkRepository.page(env.DB, { limit: 2, status: "active", now: NOW });
+    expect(result.total).toBe(3);
+    expect(result.links).toHaveLength(2);
+    expect(result.links.every((l) => l.expires_at === null)).toBe(true);
+  });
+});
+
+describe("LinkRepository.page search", () => {
+  it("matches label, url and slug", async () => {
+    await LinkRepository.create(env.DB, { url: "https://example.com/docs", slug: "aaa", label: "Handbook" });
+    await LinkRepository.create(env.DB, { url: "https://other.test/x", slug: "handy", label: null });
+    await LinkRepository.create(env.DB, { url: "https://nomatch.test/x", slug: "zzz", label: null });
+
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "handbook" })).total).toBe(1);
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "example.com" })).total).toBe(1);
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "hand" })).total).toBe(2);
+  });
+
+  it("matches created_by only when searchOwner is set", async () => {
+    await LinkRepository.create(env.DB, {
+      url: "https://example.com",
+      slug: "aaa",
+      createdBy: "dennis@example.com",
+    });
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "dennis" })).total).toBe(0);
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "dennis", searchOwner: true })).total).toBe(1);
+  });
+
+  it("counts a link once even when several of its slugs match", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "promo-a" });
+    await SlugRepository.addCustom(env.DB, link.id, "promo-b");
+    await SlugRepository.addCustom(env.DB, link.id, "promo-c");
+
+    const result = await LinkRepository.page(env.DB, { limit: 25, search: "promo" });
+    expect(result.total).toBe(1);
+    expect(result.links).toHaveLength(1);
+  });
+
+  it("treats LIKE metacharacters as literals", async () => {
+    await LinkRepository.create(env.DB, { url: "https://example.com/50%25-off", slug: "aaa" });
+    await LinkRepository.create(env.DB, { url: "https://example.com/plain", slug: "bbb" });
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "%" })).total).toBe(1);
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "_" })).total).toBe(0);
+  });
+
+  it("returns nothing for a blank search", async () => {
+    await seed(3);
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "   " })).total).toBe(0);
+    expect((await LinkRepository.page(env.DB, { limit: 25, search: "" })).total).toBe(0);
+  });
+
+  it("windows search results instead of loading every match", async () => {
+    await seed(30, "match");
+    const result = await LinkRepository.page(env.DB, { limit: 10, search: "match" });
+    expect(result.total).toBe(30);
+    expect(result.links).toHaveLength(10);
+  });
+
+  it("combines search with the status filter", async () => {
+    const live = await LinkRepository.create(env.DB, { url: "https://example.com/a", slug: "keep-a" });
+    const dead = await LinkRepository.create(env.DB, { url: "https://example.com/b", slug: "keep-b" });
+    await LinkRepository.update(env.DB, dead.id, { expires_at: NOW - 10 });
+
+    const active = await LinkRepository.page(env.DB, { limit: 25, search: "keep", status: "active", now: NOW });
+    expect(active.links.map((l) => l.id)).toEqual([live.id]);
+    const all = await LinkRepository.page(env.DB, { limit: 25, search: "keep", status: "all", now: NOW });
+    expect(all.total).toBe(2);
+  });
+});
+
+describe("LinkRepository.count", () => {
+  it("counts the catalog ignoring the status filter", async () => {
+    await seed(3);
+    const expired = await LinkRepository.create(env.DB, { url: "https://dead.com", slug: "dead" });
+    await LinkRepository.update(env.DB, expired.id, { expires_at: NOW - 10 });
+    expect(await LinkRepository.count(env.DB)).toBe(4);
+  });
+
+  it("counts search matches", async () => {
+    await LinkRepository.create(env.DB, { url: "https://example.com", slug: "aaa", label: "Handbook" });
+    await LinkRepository.create(env.DB, { url: "https://other.test", slug: "bbb" });
+    expect(await LinkRepository.count(env.DB, { search: "handbook" })).toBe(1);
+    expect(await LinkRepository.count(env.DB, { search: "nothing" })).toBe(0);
+  });
+});

--- a/src/__tests__/repository/link-page.test.ts
+++ b/src/__tests__/repository/link-page.test.ts
@@ -307,4 +307,26 @@ describe("LinkRepository.count", () => {
     expect(await LinkRepository.count(env.DB, { search: "handbook" })).toBe(1);
     expect(await LinkRepository.count(env.DB, { search: "nothing" })).toBe(0);
   });
+
+  it("agrees with page().total under every filter combination", async () => {
+    // page() derives its total from count(), so the empty-state count the
+    // service takes and the total the toolbar renders cannot disagree.
+    await seed(4, "live");
+    const expired = await LinkRepository.create(env.DB, { url: "https://dead.com", slug: "dead-one" });
+    await LinkRepository.update(env.DB, expired.id, { expires_at: NOW - 10 });
+
+    const cases = [
+      {},
+      { status: "active" as const },
+      { status: "disabled" as const },
+      { status: "all" as const },
+      { search: "live" },
+      { search: "dead", status: "disabled" as const },
+      { search: "nomatch" },
+    ];
+    for (const query of cases) {
+      const paged = await LinkRepository.page(env.DB, { ...query, limit: 2, now: NOW });
+      expect(paged.total).toBe(await LinkRepository.count(env.DB, { ...query, now: NOW }));
+    }
+  });
 });

--- a/src/__tests__/repository/link-query-cost.test.ts
+++ b/src/__tests__/repository/link-query-cost.test.ts
@@ -1,0 +1,130 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { applyMigrations, resetData, spyDb } from "../setup";
+import { LinkRepository, SlugRepository } from "../../db";
+
+beforeAll(applyMigrations);
+beforeEach(resetData);
+
+async function seed(count: number, prefix: string, owner?: string): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await LinkRepository.create(env.DB, {
+      url: `https://example.com/${prefix}${i}`,
+      slug: `${prefix}${i}`,
+      createdBy: owner,
+    });
+  }
+}
+
+describe("unwindowed link queries cost the same at any match count", () => {
+  it("search issues two statements for 3 matches and two for 40", async () => {
+    await seed(3, "hit");
+    const few: string[] = [];
+    expect(await LinkRepository.search(spyDb(few), "hit")).toHaveLength(3);
+
+    await resetData();
+    await seed(40, "hit");
+    const many: string[] = [];
+    expect(await LinkRepository.search(spyDb(many), "hit")).toHaveLength(40);
+
+    // One statement per match was the failure this route set out to remove: a
+    // broad search over a large catalog trips D1's per-invocation subrequest
+    // limit. Pin the absolute count, not just the equality.
+    expect(few).toHaveLength(2);
+    expect(many).toHaveLength(2);
+  });
+
+  it("findByOwner issues two statements for 3 links and two for 40", async () => {
+    await seed(3, "own", "dennis@oddbit.id");
+    const few: string[] = [];
+    expect(await LinkRepository.findByOwner(spyDb(few), "dennis@oddbit.id")).toHaveLength(3);
+
+    await resetData();
+    await seed(40, "own", "dennis@oddbit.id");
+    const many: string[] = [];
+    expect(await LinkRepository.findByOwner(spyDb(many), "dennis@oddbit.id")).toHaveLength(40);
+
+    expect(few).toHaveLength(2);
+    expect(many).toHaveLength(2);
+  });
+
+  it("list issues two statements whatever the catalog size", async () => {
+    await seed(3, "all");
+    const few: string[] = [];
+    expect(await LinkRepository.list(spyDb(few))).toHaveLength(3);
+
+    await resetData();
+    await seed(40, "all");
+    const many: string[] = [];
+    expect(await LinkRepository.list(spyDb(many))).toHaveLength(40);
+
+    expect(few).toHaveLength(2);
+    expect(many).toHaveLength(2);
+  });
+});
+
+describe("one SQL definition of search across every entry point", () => {
+  it("search and the paginated listing return the same links in the same order", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    // Same created_at across all three, so tie ordering is what decides.
+    for (const slug of ["match-a", "match-b", "match-c"]) {
+      const link = await LinkRepository.create(env.DB, { url: `https://example.com/${slug}`, slug });
+      await env.DB.prepare("UPDATE links SET created_at = ? WHERE id = ?").bind(now, link.id).run();
+    }
+    await LinkRepository.create(env.DB, { url: "https://other.test", slug: "nope" });
+
+    const direct = await LinkRepository.search(env.DB, "match");
+    const paged = await LinkRepository.page(env.DB, { limit: 25, search: "match", status: "all" });
+
+    expect(direct.map((l) => l.id)).toEqual(paged.links.map((l) => l.id));
+  });
+
+  it("counts a link once when several of its slugs match", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://oddbit.id", slug: "dup-one" });
+    await SlugRepository.addCustom(env.DB, link.id, "dup-two");
+    await SlugRepository.addCustom(env.DB, link.id, "dup-three");
+
+    const results = await LinkRepository.search(env.DB, "dup");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].slugs).toHaveLength(3);
+  });
+
+  it("matches created_by only when includeOwner is set", async () => {
+    await LinkRepository.create(env.DB, {
+      url: "https://example.com",
+      slug: "owned",
+      createdBy: "dennis@oddbit.id",
+    });
+
+    expect(await LinkRepository.search(env.DB, "dennis")).toHaveLength(0);
+    expect(await LinkRepository.search(env.DB, "dennis", { includeOwner: true })).toHaveLength(1);
+  });
+
+  it("treats LIKE metacharacters in a search as literals", async () => {
+    await LinkRepository.create(env.DB, { url: "https://example.com/50%25-off", slug: "pct" });
+    await LinkRepository.create(env.DB, { url: "https://example.com/plain", slug: "plain" });
+
+    expect(await LinkRepository.search(env.DB, "%")).toHaveLength(1);
+  });
+
+  it("orders every unwindowed listing newest first with an id tie-break", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const ids: number[] = [];
+    for (const slug of ["tie-a", "tie-b", "tie-c"]) {
+      const link = await LinkRepository.create(env.DB, { url: `https://example.com/${slug}`, slug });
+      await env.DB.prepare("UPDATE links SET created_at = ? WHERE id = ?").bind(now, link.id).run();
+      ids.push(link.id);
+    }
+    const newestFirst = [...ids].reverse();
+
+    // created_at is second-granularity, so links created in the same second
+    // need the tie-break to come back in a stable order on every surface.
+    expect((await LinkRepository.list(env.DB)).map((l) => l.id)).toEqual(newestFirst);
+    expect((await LinkRepository.search(env.DB, "tie")).map((l) => l.id)).toEqual(newestFirst);
+    expect((await LinkRepository.findByOwner(env.DB, "anonymous")).map((l) => l.id)).toEqual(newestFirst);
+  });
+});

--- a/src/__tests__/repository/link-query-cost.test.ts
+++ b/src/__tests__/repository/link-query-cost.test.ts
@@ -51,6 +51,20 @@ describe("unwindowed link queries cost the same at any match count", () => {
     expect(many).toHaveLength(2);
   });
 
+  it("findByUrl issues two statements for 3 duplicates and two for 40", async () => {
+    const url = "https://example.com/dupe";
+    for (let i = 0; i < 3; i++) await LinkRepository.create(env.DB, { url, slug: `u${i}` });
+    const few: string[] = [];
+    expect(await LinkRepository.findByUrl(spyDb(few), url)).toHaveLength(3);
+
+    for (let i = 3; i < 40; i++) await LinkRepository.create(env.DB, { url, slug: `u${i}` });
+    const many: string[] = [];
+    expect(await LinkRepository.findByUrl(spyDb(many), url)).toHaveLength(40);
+
+    expect(few).toHaveLength(2);
+    expect(many).toHaveLength(2);
+  });
+
   it("list issues two statements whatever the catalog size", async () => {
     await seed(3, "all");
     const few: string[] = [];

--- a/src/__tests__/service/link-page-service.test.ts
+++ b/src/__tests__/service/link-page-service.test.ts
@@ -23,37 +23,32 @@ describe("listLinksPage", () => {
   it("returns one window plus the page arithmetic", async () => {
     await seed(30);
     const result = await listLinksPage(env as never, { page: 1, perPage: 25 });
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.links).toHaveLength(25);
-    expect(result.data.total).toBe(30);
-    expect(result.data.totalPages).toBe(2);
-    expect(result.data.page).toBe(1);
+    expect(result.links).toHaveLength(25);
+    expect(result.total).toBe(30);
+    expect(result.totalPages).toBe(2);
+    expect(result.page).toBe(1);
   });
 
   it("clamps a page past the end and reports the page it served", async () => {
     await seed(30);
     const result = await listLinksPage(env as never, { page: 99, perPage: 25 });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.page).toBe(2);
-    expect(result.data.links).toHaveLength(5);
+    expect(result.page).toBe(2);
+    expect(result.links).toHaveLength(5);
   });
 
   it("clamps perPage to the maximum so a crafted query cannot request the catalog", async () => {
     await seed(30);
     const result = await listLinksPage(env as never, { page: 1, perPage: 100000 });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.perPage).toBe(LINKS_MAX_PER_PAGE);
-    expect(result.data.links.length).toBeLessThanOrEqual(LINKS_MAX_PER_PAGE);
+    expect(result.perPage).toBe(LINKS_MAX_PER_PAGE);
+    expect(result.links.length).toBeLessThanOrEqual(LINKS_MAX_PER_PAGE);
   });
 
   it("clamps a non-positive perPage to one row", async () => {
     await seed(3);
     const result = await listLinksPage(env as never, { page: 1, perPage: -5 });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.perPage).toBe(1);
-    expect(result.data.links).toHaveLength(1);
-    expect(result.data.totalPages).toBe(3);
+    expect(result.perPage).toBe(1);
+    expect(result.links).toHaveLength(1);
+    expect(result.totalPages).toBe(3);
   });
 
   it("attaches deltas to the served rows only", async () => {
@@ -63,26 +58,23 @@ describe("listLinksPage", () => {
     await insert.bind("s1", NOW - 40 * 86400).run();
 
     const result = await listLinksPage(env as never, { page: 1, perPage: 1, withDeltaRange: "30d", range: "30d" });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.links).toHaveLength(1);
-    expect(result.data.links[0].delta_pct).toBe(0);
+    expect(result.links).toHaveLength(1);
+    expect(result.links[0].delta_pct).toBe(0);
   });
 
   it("reports no-links for an empty catalog", async () => {
     const result = await listLinksPage(env as never, { page: 1, perPage: 25 });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.total).toBe(0);
-    expect(result.data.emptyReason).toBe("no-links");
-    expect(result.data.totalPages).toBe(1);
+    expect(result.total).toBe(0);
+    expect(result.emptyReason).toBe("no-links");
+    expect(result.totalPages).toBe(1);
   });
 
   it("reports all-disabled when the active filter hid every link", async () => {
     const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
     await LinkRepository.update(env.DB, link.id, { expires_at: NOW - 10 });
     const result = await listLinksPage(env as never, { page: 1, perPage: 25, status: "active" });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.total).toBe(0);
-    expect(result.data.emptyReason).toBe("all-disabled");
+    expect(result.total).toBe(0);
+    expect(result.emptyReason).toBe("all-disabled");
   });
 
   it("reports no-matches when the disabled filter finds nothing to show", async () => {
@@ -90,22 +82,19 @@ describe("listLinksPage", () => {
     // disabled" would state the opposite of the truth.
     await seed(3);
     const result = await listLinksPage(env as never, { page: 1, perPage: 25, status: "disabled" });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.total).toBe(0);
-    expect(result.data.emptyReason).toBe("no-matches");
+    expect(result.total).toBe(0);
+    expect(result.emptyReason).toBe("no-matches");
   });
 
   it("reports no-matches when a search finds nothing in a populated catalog", async () => {
     await seed(3);
     const result = await listLinksPage(env as never, { page: 1, perPage: 25, search: "xyzzy-nothing" });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.emptyReason).toBe("no-matches");
+    expect(result.emptyReason).toBe("no-matches");
   });
 
   it("reports no-links for an empty catalog even under a search", async () => {
     const result = await listLinksPage(env as never, { page: 1, perPage: 25, search: "anything" });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.emptyReason).toBe("no-links");
+    expect(result.emptyReason).toBe("no-links");
   });
 
   it("names a reason whenever the served window is empty, not only when the total is zero", async () => {
@@ -114,24 +103,36 @@ describe("listLinksPage", () => {
     // page would otherwise print "30 links" above "No links yet".
     await seed(3);
     const result = await listLinksPage(env as never, { page: 1, perPage: 25, status: "disabled" });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.links).toHaveLength(0);
-    expect(result.data.emptyReason).toBeDefined();
+    expect(result.links).toHaveLength(0);
+    expect(result.emptyReason).toBeDefined();
+  });
+
+  it("owns every page and per-page guard, whatever the route hands over", async () => {
+    await seed(30);
+    // The route parses query params and does not clamp them, so the service is
+    // the single place these rules live.
+    for (const page of [0, -3, 0.5, NaN]) {
+      const result = await listLinksPage(env as never, { page, perPage: 25 });
+      expect(result.page).toBe(1);
+      expect(result.links).toHaveLength(25);
+    }
+    for (const perPage of [0, -5, NaN]) {
+      const result = await listLinksPage(env as never, { page: 1, perPage });
+      expect(result.perPage).toBeGreaterThanOrEqual(1);
+    }
   });
 
   it("leaves emptyReason unset when the window has rows", async () => {
     await seed(1);
     const result = await listLinksPage(env as never, { page: 1, perPage: 25 });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.emptyReason).toBeUndefined();
+    expect(result.emptyReason).toBeUndefined();
   });
 
   it("windows a search instead of loading every match", async () => {
     await seed(30);
     const result = await listLinksPage(env as never, { page: 2, perPage: 10, search: "example", includeOwner: true });
-    if (!result.ok) throw new Error("expected ok");
-    expect(result.data.total).toBe(30);
-    expect(result.data.links).toHaveLength(10);
-    expect(result.data.totalPages).toBe(3);
+    expect(result.total).toBe(30);
+    expect(result.links).toHaveLength(10);
+    expect(result.totalPages).toBe(3);
   });
 });

--- a/src/__tests__/service/link-page-service.test.ts
+++ b/src/__tests__/service/link-page-service.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { applyMigrations, resetData } from "../setup";
+import { LinkRepository } from "../../db";
+import { listLinksPage } from "../../services";
+import { LINKS_MAX_PER_PAGE } from "../../constants";
+
+beforeAll(applyMigrations);
+beforeEach(resetData);
+
+const NOW = Math.floor(Date.now() / 1000);
+
+async function seed(count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await LinkRepository.create(env.DB, { url: `https://example${i}.com`, slug: `s${i}` });
+  }
+}
+
+describe("listLinksPage", () => {
+  it("returns one window plus the page arithmetic", async () => {
+    await seed(30);
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.links).toHaveLength(25);
+    expect(result.data.total).toBe(30);
+    expect(result.data.totalPages).toBe(2);
+    expect(result.data.page).toBe(1);
+  });
+
+  it("clamps a page past the end and reports the page it served", async () => {
+    await seed(30);
+    const result = await listLinksPage(env as never, { page: 99, perPage: 25 });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.page).toBe(2);
+    expect(result.data.links).toHaveLength(5);
+  });
+
+  it("clamps perPage to the maximum so a crafted query cannot request the catalog", async () => {
+    await seed(30);
+    const result = await listLinksPage(env as never, { page: 1, perPage: 100000 });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.perPage).toBe(LINKS_MAX_PER_PAGE);
+    expect(result.data.links.length).toBeLessThanOrEqual(LINKS_MAX_PER_PAGE);
+  });
+
+  it("clamps a non-positive perPage to one row", async () => {
+    await seed(3);
+    const result = await listLinksPage(env as never, { page: 1, perPage: -5 });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.perPage).toBe(1);
+    expect(result.data.links).toHaveLength(1);
+    expect(result.data.totalPages).toBe(3);
+  });
+
+  it("attaches deltas to the served rows only", async () => {
+    await seed(2);
+    const insert = env.DB.prepare("INSERT INTO clicks (slug, clicked_at) VALUES (?, ?)");
+    await insert.bind("s1", NOW - 60).run();
+    await insert.bind("s1", NOW - 40 * 86400).run();
+
+    const result = await listLinksPage(env as never, { page: 1, perPage: 1, withDeltaRange: "30d", range: "30d" });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.links).toHaveLength(1);
+    expect(result.data.links[0].delta_pct).toBe(0);
+  });
+
+  it("reports no-links for an empty catalog", async () => {
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25 });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.total).toBe(0);
+    expect(result.data.emptyReason).toBe("no-links");
+    expect(result.data.totalPages).toBe(1);
+  });
+
+  it("reports all-filtered when the status filter hid every link", async () => {
+    const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
+    await LinkRepository.update(env.DB, link.id, { expires_at: NOW - 10 });
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25, status: "active" });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.total).toBe(0);
+    expect(result.data.emptyReason).toBe("all-filtered");
+  });
+
+  it("leaves emptyReason unset when the window has rows", async () => {
+    await seed(1);
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25 });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.emptyReason).toBeUndefined();
+  });
+
+  it("windows a search instead of loading every match", async () => {
+    await seed(30);
+    const result = await listLinksPage(env as never, { page: 2, perPage: 10, search: "example", includeOwner: true });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.total).toBe(30);
+    expect(result.data.links).toHaveLength(10);
+    expect(result.data.totalPages).toBe(3);
+  });
+});

--- a/src/__tests__/service/link-page-service.test.ts
+++ b/src/__tests__/service/link-page-service.test.ts
@@ -76,13 +76,47 @@ describe("listLinksPage", () => {
     expect(result.data.totalPages).toBe(1);
   });
 
-  it("reports all-filtered when the status filter hid every link", async () => {
+  it("reports all-disabled when the active filter hid every link", async () => {
     const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
     await LinkRepository.update(env.DB, link.id, { expires_at: NOW - 10 });
     const result = await listLinksPage(env as never, { page: 1, perPage: 25, status: "active" });
     if (!result.ok) throw new Error("expected ok");
     expect(result.data.total).toBe(0);
-    expect(result.data.emptyReason).toBe("all-filtered");
+    expect(result.data.emptyReason).toBe("all-disabled");
+  });
+
+  it("reports no-matches when the disabled filter finds nothing to show", async () => {
+    // The inverse of the case above: every link is active, so "all links are
+    // disabled" would state the opposite of the truth.
+    await seed(3);
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25, status: "disabled" });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.total).toBe(0);
+    expect(result.data.emptyReason).toBe("no-matches");
+  });
+
+  it("reports no-matches when a search finds nothing in a populated catalog", async () => {
+    await seed(3);
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25, search: "xyzzy-nothing" });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.emptyReason).toBe("no-matches");
+  });
+
+  it("reports no-links for an empty catalog even under a search", async () => {
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25, search: "anything" });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.emptyReason).toBe("no-links");
+  });
+
+  it("names a reason whenever the served window is empty, not only when the total is zero", async () => {
+    // The total and the window come from separate statements. Deleting rows
+    // between them leaves a positive total with nothing to render, and the
+    // page would otherwise print "30 links" above "No links yet".
+    await seed(3);
+    const result = await listLinksPage(env as never, { page: 1, perPage: 25, status: "disabled" });
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.data.links).toHaveLength(0);
+    expect(result.data.emptyReason).toBeDefined();
   });
 
   it("leaves emptyReason unset when the window has rows", async () => {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -47,3 +47,30 @@ export async function resetData() {
   const { keys } = await kv.list();
   await Promise.all(keys.map((k) => kv.delete(k.name)));
 }
+
+/**
+ * Records the SQL of every statement a call issues, so a test can pin both the
+ * cost of an operation and the shape of what it sends. Traps exec() alongside
+ * prepare(): batch() composes already-prepared statements and so is recorded
+ * through prepare, but exec() takes raw SQL and would slip past entirely.
+ */
+export function spyDb(log: string[]): D1Database {
+  return new Proxy(env.DB, {
+    get(target, prop, receiver) {
+      if (prop === "prepare") {
+        return (sql: string) => {
+          log.push(sql);
+          return (target as unknown as D1Database).prepare(sql);
+        };
+      }
+      if (prop === "exec") {
+        return (sql: string) => {
+          log.push(sql);
+          return (target as unknown as D1Database).exec(sql);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as unknown as D1Database;
+}

--- a/src/__tests__/unit/click-count-sql.test.ts
+++ b/src/__tests__/unit/click-count-sql.test.ts
@@ -1,0 +1,32 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { linkClickCountSql, slugClickCountSql } from "../../db/filters";
+
+const OPTS = {
+  filters: { excludeBots: true, excludeSelfReferrers: true },
+  sinceTs: 1_700_000_000.7,
+};
+
+describe("click-count SQL fragments", () => {
+  it("closes both fragments with the identical filter and window tail", () => {
+    // Popular ordering ranks links by linkClickCountSql while each row renders
+    // a slugClickCountSql total. A tail that drifts between the two ranks by
+    // one number and prints another, so pin them to the same literal.
+    const tail = " AND c.is_bot = 0 AND c.is_self_referrer = 0 AND c.clicked_at >= 1700000000)";
+    expect(slugClickCountSql(OPTS)).toContain(tail);
+    expect(linkClickCountSql(OPTS)).toContain(tail);
+  });
+
+  it("emits no tail when neither filters nor a window are asked for", () => {
+    expect(slugClickCountSql()).toBe("(SELECT COUNT(*) FROM clicks c WHERE c.slug = s.slug) AS click_count");
+    expect(linkClickCountSql()).toBe(
+      "(SELECT COUNT(*) FROM clicks c JOIN slugs cs ON c.slug = cs.slug WHERE cs.link_id = l.id)",
+    );
+  });
+
+  it("keeps the link fragment correlated to the alias the caller gave the links table", () => {
+    expect(linkClickCountSql(undefined, "lk")).toContain("cs.link_id = lk.id");
+  });
+});

--- a/src/__tests__/unit/links-pagination.test.ts
+++ b/src/__tests__/unit/links-pagination.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { paginationItems } from "../../pages/links";
+import { pageWindow, paginationItems } from "../../pages/links";
 
 describe("links pagination window", () => {
   it("falls through to the near-end window at the 8-page boundary", () => {
@@ -59,5 +59,35 @@ describe("links pagination window", () => {
       187,
       188,
     ]);
+  });
+});
+
+describe("links page window", () => {
+  it("clamps a total below one page to page 1 and a non-negative row range", () => {
+    // An htmx partial computing Math.ceil(0 / perPage) hands over totalPages: 0.
+    // Without the clamp currentPage lands on 0 and start on -perPage, which
+    // renders "-24 - 0 of 0" and links to page=0.
+    expect(pageWindow(1, 25, 0)).toEqual({ currentPage: 1, pageCount: 1, perPage: 25, start: 0 });
+  });
+
+  it("clamps a page past the end onto the last page", () => {
+    expect(pageWindow(9, 25, 3)).toEqual({ currentPage: 3, pageCount: 3, perPage: 25, start: 50 });
+  });
+
+  it("clamps a page below the first onto page 1", () => {
+    expect(pageWindow(0, 25, 3)).toEqual({ currentPage: 1, pageCount: 3, perPage: 25, start: 0 });
+    expect(pageWindow(-4, 25, 3)).toEqual({ currentPage: 1, pageCount: 3, perPage: 25, start: 0 });
+  });
+
+  it("floors a non-positive per-page to one row rather than a zero-width window", () => {
+    expect(pageWindow(2, 0, 5)).toEqual({ currentPage: 2, pageCount: 5, perPage: 1, start: 1 });
+  });
+
+  it("leaves an oversized per-page alone, since the service owns the upper bound", () => {
+    expect(pageWindow(1, 1000, 1).perPage).toBe(1000);
+  });
+
+  it("survives unparseable inputs", () => {
+    expect(pageWindow(NaN, NaN, NaN)).toEqual({ currentPage: 1, pageCount: 1, perPage: 1, start: 0 });
   });
 });

--- a/src/__tests__/unit/links-per-page.test.ts
+++ b/src/__tests__/unit/links-per-page.test.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { LINKS_DEFAULT_PER_PAGE, LINKS_MAX_PER_PAGE, LINKS_PER_PAGE_OPTIONS } from "../../constants";
+
+describe("links per-page bounds", () => {
+  it("caps at the largest option the selector offers", () => {
+    // A cap below the largest option would serve a clamped row count while the
+    // selector renders no <option selected>, so the browser shows the first
+    // option next to a differently sized table.
+    expect(LINKS_MAX_PER_PAGE).toBe(Math.max(...LINKS_PER_PAGE_OPTIONS));
+  });
+
+  it("defaults to one of the offered options", () => {
+    expect(LINKS_PER_PAGE_OPTIONS).toContain(LINKS_DEFAULT_PER_PAGE);
+  });
+});

--- a/src/__tests__/unit/links-per-page.test.ts
+++ b/src/__tests__/unit/links-per-page.test.ts
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { LINKS_DEFAULT_PER_PAGE, LINKS_MAX_PER_PAGE, LINKS_PER_PAGE_OPTIONS } from "../../constants";
+import {
+  D1_MAX_BOUND_PARAMS,
+  LINKS_DEFAULT_PER_PAGE,
+  LINKS_MAX_PER_PAGE,
+  LINKS_PER_PAGE_OPTIONS,
+} from "../../constants";
 
 describe("links per-page bounds", () => {
   it("caps at the largest option the selector offers", () => {
@@ -10,6 +15,12 @@ describe("links per-page bounds", () => {
     // selector renders no <option selected>, so the browser shows the first
     // option next to a differently sized table.
     expect(LINKS_MAX_PER_PAGE).toBe(Math.max(...LINKS_PER_PAGE_OPTIONS));
+  });
+
+  it("keeps every option inside D1's per-statement parameter cap", () => {
+    // page() binds one parameter per served row to fetch that row's slugs, so
+    // an option above the cap would fail the slug query outright.
+    expect(LINKS_MAX_PER_PAGE).toBeLessThanOrEqual(D1_MAX_BOUND_PARAMS);
   });
 
   it("defaults to one of the offered options", () => {

--- a/src/__tests__/unit/trends.test.ts
+++ b/src/__tests__/unit/trends.test.ts
@@ -1,7 +1,8 @@
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { env } from "cloudflare:test";
-import { applyMigrations, resetData } from "../setup";
+import { applyMigrations, resetData, spyDb } from "../setup";
 import { LinkRepository, ClickRepository } from "../../db";
+import type { LinkWithSlugs } from "../../types";
 import { computeDelta, formatAvgPerDay } from "../../services/trends";
 
 beforeAll(applyMigrations);
@@ -158,6 +159,47 @@ describe("ClickRepository.attachLinkDeltasBulk", () => {
     const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "abc" });
     const [out] = await ClickRepository.attachLinkDeltasBulk(env.DB, [link], "24h");
     expect(out.delta_pct).toBeUndefined();
+  });
+
+  it("aggregates only the clicks of the links it was handed", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const served = await LinkRepository.create(env.DB, { url: "https://a.example", slug: "served" });
+    const other = await LinkRepository.create(env.DB, { url: "https://b.example", slug: "other" });
+    const insertClick = (slug: string, t: number) =>
+      env.DB.prepare("INSERT INTO clicks (slug, clicked_at) VALUES (?, ?)").bind(slug, t).run();
+    for (let i = 0; i < 4; i++) await insertClick(served.slugs[0].slug, now - i * 60);
+    for (let i = 0; i < 2; i++) await insertClick(served.slugs[0].slug, now - 86401 - i * 60);
+    // Clicks on a link outside the window: the group-by must not read them.
+    for (let i = 0; i < 50; i++) await insertClick(other.slugs[0].slug, now - i * 60);
+
+    const log: string[] = [];
+    const [out] = await ClickRepository.attachLinkDeltasBulk(spyDb(log), [served], "24h", now);
+
+    expect(out.delta_pct).toBe(100);
+    // Clicks grow faster than links, so an unrestricted GROUP BY makes the
+    // delta pills the largest scan on a page that renders 25 rows.
+    expect(log.every((sql) => sql.includes("s.link_id IN (?)"))).toBe(true);
+  });
+
+  it("keeps deltas correct for a set too large to bind, without the id restriction", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const links: LinkWithSlugs[] = [];
+    for (let i = 0; i < 101; i++) {
+      links.push(await LinkRepository.create(env.DB, { url: `https://e${i}.example`, slug: `wide${i}` }));
+    }
+    const insertClick = (slug: string, t: number) =>
+      env.DB.prepare("INSERT INTO clicks (slug, clicked_at) VALUES (?, ?)").bind(slug, t).run();
+    for (let i = 0; i < 6; i++) await insertClick(links[0].slugs[0].slug, now - i * 60);
+    for (let i = 0; i < 3; i++) await insertClick(links[0].slugs[0].slug, now - 86401 - i * 60);
+
+    const log: string[] = [];
+    const out = await ClickRepository.attachLinkDeltasBulk(spyDb(log), links, "24h", now);
+
+    // Above D1's parameter cap the ids cannot be bound, and a caller asking
+    // for every link wants the whole aggregate anyway.
+    expect(log.every((sql) => !sql.includes("s.link_id IN"))).toBe(true);
+    expect(log).toHaveLength(2);
+    expect(out.find((l) => l.id === links[0].id)?.delta_pct).toBe(100);
   });
 
   it("leaves delta undefined when previous window is zero but current has clicks", async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,13 @@ export const BREAKDOWN_PAGE_SIZE = 10;
 // Upper bound a single breakdown request may fetch.
 export const MAX_BREAKDOWN_LIMIT = 100;
 
+// Links listing page size. The options feed the per-page selector, and the
+// maximum caps what a hand-edited per_page query can pull into one page so the
+// route's cost stays bounded by the window, not by the catalog.
+export const LINKS_PER_PAGE_OPTIONS = [25, 50, 100] as const;
+export const LINKS_DEFAULT_PER_PAGE: (typeof LINKS_PER_PAGE_OPTIONS)[number] = 25;
+export const LINKS_MAX_PER_PAGE = 100;
+
 export const THEMES = ["oddbit", "dark", "light"] as const;
 export const DEFAULT_THEME: (typeof THEMES)[number] = "oddbit";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,9 +19,14 @@ export const BREAKDOWN_PAGE_SIZE = 10;
 // Upper bound a single breakdown request may fetch.
 export const MAX_BREAKDOWN_LIMIT = 100;
 
+// D1 accepts at most this many bound parameters in one statement.
+export const D1_MAX_BOUND_PARAMS = 100;
+
 // Links listing page size. The options feed the per-page selector, and the
 // maximum caps what a hand-edited per_page query can pull into one page so the
-// route's cost stays bounded by the window, not by the catalog.
+// route's cost stays bounded by the window, not by the catalog. LinkRepository
+// .page() binds one parameter per served row to fetch its slugs, so no option
+// may exceed D1_MAX_BOUND_PARAMS.
 export const LINKS_PER_PAGE_OPTIONS = [25, 50, 100] as const;
 export const LINKS_DEFAULT_PER_PAGE: (typeof LINKS_PER_PAGE_OPTIONS)[number] = 25;
 export const LINKS_MAX_PER_PAGE = Math.max(...LINKS_PER_PAGE_OPTIONS);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,7 @@ export const MAX_BREAKDOWN_LIMIT = 100;
 // route's cost stays bounded by the window, not by the catalog.
 export const LINKS_PER_PAGE_OPTIONS = [25, 50, 100] as const;
 export const LINKS_DEFAULT_PER_PAGE: (typeof LINKS_PER_PAGE_OPTIONS)[number] = 25;
-export const LINKS_MAX_PER_PAGE = 100;
+export const LINKS_MAX_PER_PAGE = Math.max(...LINKS_PER_PAGE_OPTIONS);
 
 export const THEMES = ["oddbit", "dark", "light"] as const;
 export const DEFAULT_THEME: (typeof THEMES)[number] = "oddbit";

--- a/src/db/click-repository.ts
+++ b/src/db/click-repository.ts
@@ -6,6 +6,7 @@ import { LinkRepository } from "./link-repository";
 import { BundleRepository } from "./bundle-repository";
 import { RANGE_SECONDS, computeDelta } from "../services/trends";
 import { ClickFilters, clickFilterSql } from "./filters";
+import { D1_MAX_BOUND_PARAMS } from "../constants";
 import type { PaginatedDimension } from "../constants";
 
 export type BreakdownDimension = "country" | "referrer_host" | "device_type" | "os" | "browser" | "link_mode" | "channel";
@@ -772,22 +773,34 @@ export class ClickRepository {
 
     const ts = now ?? Math.floor(Date.now() / 1000);
     const span = RANGE_SECONDS[range];
-    const currStart = ts - span;
-    const prevStart = ts - 2 * span;
+    const currStart = Math.floor(ts - span);
+    const prevStart = Math.floor(ts - 2 * span);
     const filterFrag = clickFilterSql(filters, "c");
+
+    // Clicks outgrow links, so grouping every click in the range to label one
+    // page of rows is the largest scan on that request. Restrict the group-by
+    // to the ids being served. Past D1's parameter cap the ids will not bind,
+    // and a caller handing over the whole catalog wants the full aggregate
+    // anyway, so that case keeps the unrestricted query. The window bounds go
+    // inline, as in clickWindowSql, leaving the binds for ids.
+    const ids = links.map((l) => l.id);
+    const scope = ids.length <= D1_MAX_BOUND_PARAMS
+      ? ` AND s.link_id IN (${ids.map(() => "?").join(",")})`
+      : "";
+    const scopeBinds = scope ? ids : [];
 
     const [curRows, prevRows] = await Promise.all([
       db
         .prepare(
-          `SELECT s.link_id as link_id, COUNT(*) as cnt FROM clicks c JOIN slugs s ON c.slug = s.slug WHERE c.clicked_at >= ?${filterFrag} GROUP BY s.link_id`,
+          `SELECT s.link_id as link_id, COUNT(*) as cnt FROM clicks c JOIN slugs s ON c.slug = s.slug WHERE c.clicked_at >= ${currStart}${filterFrag}${scope} GROUP BY s.link_id`,
         )
-        .bind(currStart)
+        .bind(...scopeBinds)
         .all<{ link_id: number; cnt: number }>(),
       db
         .prepare(
-          `SELECT s.link_id as link_id, COUNT(*) as cnt FROM clicks c JOIN slugs s ON c.slug = s.slug WHERE c.clicked_at >= ? AND c.clicked_at < ?${filterFrag} GROUP BY s.link_id`,
+          `SELECT s.link_id as link_id, COUNT(*) as cnt FROM clicks c JOIN slugs s ON c.slug = s.slug WHERE c.clicked_at >= ${prevStart} AND c.clicked_at < ${currStart}${filterFrag}${scope} GROUP BY s.link_id`,
         )
-        .bind(prevStart, currStart)
+        .bind(...scopeBinds)
         .all<{ link_id: number; cnt: number }>(),
     ]);
 

--- a/src/db/filters.ts
+++ b/src/db/filters.ts
@@ -35,32 +35,40 @@ export interface SlugClickCountOptions {
 }
 
 /**
+ * Trailing conditions every click-count subquery shares: the bot and
+ * self-referrer filters, then the `clicked_at >= sinceTs` lower bound. Both
+ * count fragments below append this one string, so the invariant that popular
+ * ordering and the rendered totals count the same clicks is structural rather
+ * than a pair of matching copies. Assumes the subquery aliases clicks as `c`.
+ */
+function clickWindowSql(opts?: SlugClickCountOptions): string {
+  let frag = clickFilterSql(opts?.filters, "c");
+  if (opts?.sinceTs !== undefined) {
+    frag += ` AND c.clicked_at >= ${Math.floor(opts.sinceTs)}`;
+  }
+  return frag;
+}
+
+/**
  * SELECT-clause fragment that computes a per-slug `click_count` column,
  * optionally filtered by bot/self-referrer flags and lower-bounded by
  * `clicked_at >= sinceTs`. The fragment depends on the outer query aliasing
  * the slugs table as `s`.
  */
 export function slugClickCountSql(opts?: SlugClickCountOptions): string {
-  let frag = "(SELECT COUNT(*) FROM clicks c WHERE c.slug = s.slug";
-  frag += clickFilterSql(opts?.filters, "c");
-  if (opts?.sinceTs !== undefined) {
-    frag += ` AND c.clicked_at >= ${Math.floor(opts.sinceTs)}`;
-  }
-  return frag + ") AS click_count";
+  return `(SELECT COUNT(*) FROM clicks c WHERE c.slug = s.slug${clickWindowSql(opts)}) AS click_count`;
 }
 
 /**
- * Scalar subquery totalling a link's clicks across all its slugs, under the
- * same bot/self-referrer filters and `sinceTs` window as
- * `slugClickCountSql`. Use it to order a link query by popularity in SQL so
- * the ranking matches the `total_clicks` the caller will render. Pass the
- * alias the outer query gives the links table.
+ * Scalar subquery totalling a link's clicks across all its slugs. Shares
+ * `clickWindowSql` with `slugClickCountSql`, so it counts exactly the clicks
+ * the caller will render. Use it to order a link query by popularity in SQL
+ * and the ranking matches the printed `total_clicks`. Pass the alias the
+ * outer query gives the links table.
  */
 export function linkClickCountSql(opts?: SlugClickCountOptions, linkAlias = "l"): string {
-  let frag = `(SELECT COUNT(*) FROM clicks c JOIN slugs cs ON c.slug = cs.slug WHERE cs.link_id = ${linkAlias}.id`;
-  frag += clickFilterSql(opts?.filters, "c");
-  if (opts?.sinceTs !== undefined) {
-    frag += ` AND c.clicked_at >= ${Math.floor(opts.sinceTs)}`;
-  }
-  return frag + ")";
+  return (
+    `(SELECT COUNT(*) FROM clicks c JOIN slugs cs ON c.slug = cs.slug` +
+    ` WHERE cs.link_id = ${linkAlias}.id${clickWindowSql(opts)})`
+  );
 }

--- a/src/db/filters.ts
+++ b/src/db/filters.ts
@@ -48,3 +48,19 @@ export function slugClickCountSql(opts?: SlugClickCountOptions): string {
   }
   return frag + ") AS click_count";
 }
+
+/**
+ * Scalar subquery totalling a link's clicks across all its slugs, under the
+ * same bot/self-referrer filters and `sinceTs` window as
+ * `slugClickCountSql`. Use it to order a link query by popularity in SQL so
+ * the ranking matches the `total_clicks` the caller will render. Pass the
+ * alias the outer query gives the links table.
+ */
+export function linkClickCountSql(opts?: SlugClickCountOptions, linkAlias = "l"): string {
+  let frag = `(SELECT COUNT(*) FROM clicks c JOIN slugs cs ON c.slug = cs.slug WHERE cs.link_id = ${linkAlias}.id`;
+  frag += clickFilterSql(opts?.filters, "c");
+  if (opts?.sinceTs !== undefined) {
+    frag += ` AND c.clicked_at >= ${Math.floor(opts.sinceTs)}`;
+  }
+  return frag + ")";
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { LinkRepository } from "./link-repository";
+export type { LinkRepoOptions, LinkSort, LinkStatus, LinkPageQuery, LinkPage } from "./link-repository";
 export { SlugRepository } from "./slug-repository";
 export { ClickRepository, sparklineBucketLabels } from "./click-repository";
 export type { BreakdownDimension } from "./click-repository";
 export type { ClickFilters, SlugClickCountOptions } from "./filters";
-export { clickFilterSql, slugClickCountSql } from "./filters";
+export { clickFilterSql, slugClickCountSql, linkClickCountSql } from "./filters";
 export { SettingRepository } from "./setting-repository";
 export { ApiKeyRepository } from "./api-key-repository";
 export type { ApiKeyRow } from "./api-key-repository";

--- a/src/db/link-repository.ts
+++ b/src/db/link-repository.ts
@@ -141,13 +141,13 @@ export class LinkRepository {
     // the opposite of what an empty search box means.
     if (query.search !== undefined && !query.search.trim()) return { links: [], total: 0, offset: 0 };
 
-    const { where, binds } = linkFilterSql(query);
-    const totalRow = await db
-      .prepare(`SELECT COUNT(*) AS n FROM links l${where}`)
-      .bind(...binds)
-      .first<{ n: number }>();
-    const total = totalRow?.n ?? 0;
+    // Take the total from count() rather than building a second COUNT here:
+    // the toolbar total and the empty-state count then cannot diverge, and a
+    // later change to how rows are totalled lands in one statement.
+    const total = await LinkRepository.count(db, query);
     if (total === 0) return { links: [], total: 0, offset: 0 };
+
+    const { where, binds } = linkFilterSql(query);
 
     // A caller can ask past the end: a bookmarked page number, or rows
     // deleted since the URL was built. Serve the last populated window and

--- a/src/db/link-repository.ts
+++ b/src/db/link-repository.ts
@@ -59,6 +59,8 @@ export interface LinkPageQuery {
   searchOwner?: boolean;
   /** Exact `created_by` match. Unrelated to `searchOwner`, which widens a substring search. */
   owner?: string;
+  /** Exact `url` match, for finding the links that already point somewhere. */
+  url?: string;
   /** Reference time for the `status` comparison. Defaults to now. */
   now?: number;
 }
@@ -84,7 +86,7 @@ function likePattern(query: string): string {
   return `%${escaped}%`;
 }
 
-type LinkFilterQuery = Pick<LinkPageQuery, "status" | "search" | "searchOwner" | "owner" | "now">;
+type LinkFilterQuery = Pick<LinkPageQuery, "status" | "search" | "searchOwner" | "owner" | "url" | "now">;
 
 function linkFilterSql(query: LinkFilterQuery): LinkFilterSql {
   const conds: string[] = [];
@@ -93,6 +95,11 @@ function linkFilterSql(query: LinkFilterQuery): LinkFilterSql {
   if (query.owner !== undefined) {
     conds.push("l.created_by = ?");
     binds.push(query.owner);
+  }
+
+  if (query.url !== undefined) {
+    conds.push("l.url = ?");
+    binds.push(query.url);
   }
 
   const now = query.now ?? Math.floor(Date.now() / 1000);
@@ -304,16 +311,7 @@ export class LinkRepository {
   }
 
   static async findByUrl(db: D1Database, url: string, opts?: LinkRepoOptions): Promise<LinkWithSlugs[]> {
-    const rows = await db
-      .prepare("SELECT id FROM links WHERE url = ? ORDER BY created_at DESC")
-      .bind(url)
-      .all<{ id: number }>();
-
-    const ids = rows.results ?? [];
-    if (ids.length === 0) return [];
-
-    const results = await Promise.all(ids.map(({ id }) => LinkRepository.getById(db, id, opts)));
-    return results.filter((l): l is LinkWithSlugs => l !== null);
+    return LinkRepository.rows(db, { url }, opts);
   }
 
   static async create(

--- a/src/db/link-repository.ts
+++ b/src/db/link-repository.ts
@@ -160,27 +160,31 @@ export class LinkRepository {
     const order = query.sort === "popular"
       ? `${linkClickCountSql(opts)} DESC, l.created_at DESC, l.id DESC`
       : "l.created_at DESC, l.id DESC";
-    const windowSql = `SELECT l.id FROM links l${where} ORDER BY ${order} LIMIT ? OFFSET ?`;
+    const links = await db
+      .prepare(`SELECT l.* FROM links l${where} ORDER BY ${order} LIMIT ? OFFSET ?`)
+      .bind(...binds, limit, offset)
+      .all<Link>();
+    const rows = links.results ?? [];
+    // total came from a separate statement, so rows deleted between the two
+    // leave a positive total with nothing to serve.
+    if (rows.length === 0) return { links: [], total, offset };
 
-    const [links, slugs] = await Promise.all([
-      db
-        .prepare(`SELECT l.* FROM links l${where} ORDER BY ${order} LIMIT ? OFFSET ?`)
-        .bind(...binds, limit, offset)
-        .all<Link>(),
-      // The window repeats as a subquery instead of binding the ids it
-      // returned: D1 caps bound parameters per statement, and a 100-row page
-      // would sit at that ceiling.
-      db
-        .prepare(
-          `SELECT ${slugSelect(opts)} FROM slugs s WHERE s.link_id IN (${windowSql}) ORDER BY is_custom ASC, created_at ASC`,
-        )
-        .bind(...binds, limit, offset)
-        .all<Slug>(),
-    ]);
+    // Bind the ids the window returned rather than repeating the window as a
+    // subquery. Embedding it would run the whole WHERE + ORDER BY + LIMIT a
+    // second time, and under sort=popular that ORDER BY is a correlated
+    // COUNT over clicks per catalog row. One bind per served row keeps this
+    // inside D1's parameter cap; LINKS_PER_PAGE_OPTIONS enforces the ceiling.
+    const ids = rows.map((l) => l.id);
+    const slugs = await db
+      .prepare(
+        `SELECT ${slugSelect(opts)} FROM slugs s WHERE s.link_id IN (${ids.map(() => "?").join(",")}) ORDER BY is_custom ASC, created_at ASC`,
+      )
+      .bind(...ids)
+      .all<Slug>();
 
     const byLink = bucketByLink(slugs.results ?? []);
     return {
-      links: (links.results ?? []).map((link) => assembleLink(link, byLink.get(link.id) ?? [])),
+      links: rows.map((link) => assembleLink(link, byLink.get(link.id) ?? [])),
       total,
       offset,
     };

--- a/src/db/link-repository.ts
+++ b/src/db/link-repository.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Link, Slug, LinkWithSlugs } from "../types";
-import { SlugClickCountOptions, slugClickCountSql } from "./filters";
+import { SlugClickCountOptions, slugClickCountSql, linkClickCountSql } from "./filters";
 
 /**
  * Options that scope per-slug click counts. Repository methods that return
@@ -27,15 +27,177 @@ function assembleLink(link: Link, slugs: Slug[]): LinkWithSlugs {
   };
 }
 
+/**
+ * Buckets slug rows by `link_id` so assembly is one Map lookup per link
+ * instead of a full rescan of the slug set, which would make assembly
+ * O(links x slugs).
+ */
+function bucketByLink(slugs: Slug[]): Map<number, Slug[]> {
+  const byLink = new Map<number, Slug[]>();
+  for (const s of slugs) {
+    const arr = byLink.get(s.link_id);
+    if (arr) arr.push(s);
+    else byLink.set(s.link_id, [s]);
+  }
+  return byLink;
+}
+
+/** Sort orders the paginated listing supports. */
+export type LinkSort = "recent" | "popular";
+
+/** Lifecycle slice the paginated listing supports, decided by `expires_at`. */
+export type LinkStatus = "active" | "disabled" | "all";
+
+export interface LinkPageQuery {
+  /** Rows per page. A non-positive value yields an empty page, never the whole table. */
+  limit: number;
+  offset?: number;
+  sort?: LinkSort;
+  status?: LinkStatus;
+  /** Substring matched against label, url, any slug, and (with `searchOwner`) created_by. */
+  search?: string;
+  searchOwner?: boolean;
+  /** Reference time for the `status` comparison. Defaults to now. */
+  now?: number;
+}
+
+export interface LinkPage {
+  links: LinkWithSlugs[];
+  /** Rows matching the filters across the whole catalog, not just this window. */
+  total: number;
+  /** Offset actually served, clamped when the caller asked past the last row. */
+  offset: number;
+}
+
+/** Predicate shared by the paginated listing and its counts. */
+type LinkFilterSql = { where: string; binds: (string | number)[] };
+
+function likePattern(query: string): string {
+  // Escape SQLite LIKE metacharacters so a user query of "_" or "50%" is
+  // treated as a literal string, not a wildcard pattern.
+  const escaped = query.trim().toLowerCase()
+    .replace(/\\/g, "\\\\")
+    .replace(/%/g, "\\%")
+    .replace(/_/g, "\\_");
+  return `%${escaped}%`;
+}
+
+function linkFilterSql(query: Pick<LinkPageQuery, "status" | "search" | "searchOwner" | "now">): LinkFilterSql {
+  const conds: string[] = [];
+  const binds: (string | number)[] = [];
+
+  const now = query.now ?? Math.floor(Date.now() / 1000);
+  if (query.status === "active") {
+    conds.push("(l.expires_at IS NULL OR l.expires_at >= ?)");
+    binds.push(now);
+  } else if (query.status === "disabled") {
+    conds.push("(l.expires_at IS NOT NULL AND l.expires_at < ?)");
+    binds.push(now);
+  }
+
+  const term = query.search?.trim();
+  if (term) {
+    const pattern = likePattern(term);
+    const fields = query.searchOwner
+      ? ["lower(l.label)", "lower(l.url)", "lower(l.created_by)"]
+      : ["lower(l.label)", "lower(l.url)"];
+    const ors = fields.map((f) => `${f} LIKE ? ESCAPE '\\'`);
+    binds.push(...fields.map(() => pattern));
+    // EXISTS rather than a join: a link with several matching slugs must count
+    // once, and a joined query would need DISTINCT to say the same thing while
+    // breaking the COUNT(*) that derives the page count.
+    ors.push("EXISTS (SELECT 1 FROM slugs ms WHERE ms.link_id = l.id AND lower(ms.slug) LIKE ? ESCAPE '\\')");
+    binds.push(pattern);
+    conds.push(`(${ors.join(" OR ")})`);
+  }
+
+  return { where: conds.length ? ` WHERE ${conds.join(" AND ")}` : "", binds };
+}
+
 export class LinkRepository {
   static async list(db: D1Database, opts?: LinkRepoOptions): Promise<LinkWithSlugs[]> {
     const links = await db.prepare("SELECT * FROM links ORDER BY created_at DESC").all<Link>();
     const slugs = await db.prepare(`SELECT ${slugSelect(opts)} FROM slugs s ORDER BY is_custom ASC, created_at ASC`).all<Slug>();
 
-    return (links.results ?? []).map((link) => {
-      const linkSlugs = (slugs.results ?? []).filter((s) => s.link_id === link.id);
-      return assembleLink(link, linkSlugs);
-    });
+    const byLink = bucketByLink(slugs.results ?? []);
+    return (links.results ?? []).map((link) => assembleLink(link, byLink.get(link.id) ?? []));
+  }
+
+  /**
+   * One page of links with their slugs, plus the total the page was cut from.
+   *
+   * Three queries whatever the catalog size: a `COUNT(*)` for the total, the
+   * windowed link rows, and the slugs of only those rows. Filtering, sorting
+   * and the window all live in SQL, so a caller rendering 25 rows never loads
+   * the catalog to slice it in JS. Use this for the listings page; `list()`
+   * stays for the API and MCP callers that hand back everything.
+   */
+  static async page(db: D1Database, query: LinkPageQuery, opts?: LinkRepoOptions): Promise<LinkPage> {
+    // SQLite treats a negative LIMIT as "no limit", so a non-positive value
+    // must short-circuit rather than reach SQL and return the whole table.
+    const limit = Math.floor(query.limit);
+    if (limit <= 0) return { links: [], total: 0, offset: 0 };
+    // A search that trims to nothing matches everything under LIKE, which is
+    // the opposite of what an empty search box means.
+    if (query.search !== undefined && !query.search.trim()) return { links: [], total: 0, offset: 0 };
+
+    const { where, binds } = linkFilterSql(query);
+    const totalRow = await db
+      .prepare(`SELECT COUNT(*) AS n FROM links l${where}`)
+      .bind(...binds)
+      .first<{ n: number }>();
+    const total = totalRow?.n ?? 0;
+    if (total === 0) return { links: [], total: 0, offset: 0 };
+
+    // A caller can ask past the end: a bookmarked page number, or rows
+    // deleted since the URL was built. Serve the last populated window and
+    // report the offset used so the caller can label the page it actually got.
+    const requested = Math.max(0, Math.floor(query.offset ?? 0));
+    const offset = requested >= total ? Math.floor((total - 1) / limit) * limit : requested;
+
+    // created_at is second-granularity, so tie-break on id to keep windows
+    // disjoint when several links share a timestamp.
+    const order = query.sort === "popular"
+      ? `${linkClickCountSql(opts)} DESC, l.created_at DESC, l.id DESC`
+      : "l.created_at DESC, l.id DESC";
+    const windowSql = `SELECT l.id FROM links l${where} ORDER BY ${order} LIMIT ? OFFSET ?`;
+
+    const [links, slugs] = await Promise.all([
+      db
+        .prepare(`SELECT l.* FROM links l${where} ORDER BY ${order} LIMIT ? OFFSET ?`)
+        .bind(...binds, limit, offset)
+        .all<Link>(),
+      // The window repeats as a subquery instead of binding the ids it
+      // returned: D1 caps bound parameters per statement, and a 100-row page
+      // would sit at that ceiling.
+      db
+        .prepare(
+          `SELECT ${slugSelect(opts)} FROM slugs s WHERE s.link_id IN (${windowSql}) ORDER BY is_custom ASC, created_at ASC`,
+        )
+        .bind(...binds, limit, offset)
+        .all<Slug>(),
+    ]);
+
+    const byLink = bucketByLink(slugs.results ?? []);
+    return {
+      links: (links.results ?? []).map((link) => assembleLink(link, byLink.get(link.id) ?? [])),
+      total,
+      offset,
+    };
+  }
+
+  /**
+   * Rows matching the filters, without fetching any of them. Callers use it to
+   * tell an empty catalog from one whose links are all filtered out.
+   */
+  static async count(
+    db: D1Database,
+    query?: Pick<LinkPageQuery, "status" | "search" | "searchOwner" | "now">,
+  ): Promise<number> {
+    if (query?.search !== undefined && !query.search.trim()) return 0;
+    const { where, binds } = linkFilterSql(query ?? {});
+    const row = await db.prepare(`SELECT COUNT(*) AS n FROM links l${where}`).bind(...binds).first<{ n: number }>();
+    return row?.n ?? 0;
   }
 
   /**
@@ -68,13 +230,7 @@ export class LinkRepository {
       .bind(...ids)
       .all<Slug>();
 
-    const byLink = new Map<number, Slug[]>();
-    for (const s of slugs.results ?? []) {
-      const arr = byLink.get(s.link_id);
-      if (arr) arr.push(s);
-      else byLink.set(s.link_id, [s]);
-    }
-
+    const byLink = bucketByLink(slugs.results ?? []);
     return rows.map((link) => assembleLink(link, byLink.get(link.id) ?? []));
   }
 
@@ -222,13 +378,7 @@ export class LinkRepository {
   ): Promise<LinkWithSlugs[]> {
     if (!query.trim()) return [];
 
-    // Escape SQLite LIKE metacharacters so a user query of "_" or "50%" is
-    // treated as a literal string, not a wildcard pattern.
-    const escaped = query.trim().toLowerCase()
-      .replace(/\\/g, "\\\\")
-      .replace(/%/g, "\\%")
-      .replace(/_/g, "\\_");
-    const pattern = `%${escaped}%`;
+    const pattern = likePattern(query);
 
     const where = opts?.includeOwner
       ? "lower(l.label) LIKE ? ESCAPE '\\' OR lower(s.slug) LIKE ? ESCAPE '\\' OR lower(l.url) LIKE ? ESCAPE '\\' OR lower(l.created_by) LIKE ? ESCAPE '\\'"

--- a/src/db/link-repository.ts
+++ b/src/db/link-repository.ts
@@ -57,6 +57,8 @@ export interface LinkPageQuery {
   /** Substring matched against label, url, any slug, and (with `searchOwner`) created_by. */
   search?: string;
   searchOwner?: boolean;
+  /** Exact `created_by` match. Unrelated to `searchOwner`, which widens a substring search. */
+  owner?: string;
   /** Reference time for the `status` comparison. Defaults to now. */
   now?: number;
 }
@@ -82,9 +84,16 @@ function likePattern(query: string): string {
   return `%${escaped}%`;
 }
 
-function linkFilterSql(query: Pick<LinkPageQuery, "status" | "search" | "searchOwner" | "now">): LinkFilterSql {
+type LinkFilterQuery = Pick<LinkPageQuery, "status" | "search" | "searchOwner" | "owner" | "now">;
+
+function linkFilterSql(query: LinkFilterQuery): LinkFilterSql {
   const conds: string[] = [];
   const binds: (string | number)[] = [];
+
+  if (query.owner !== undefined) {
+    conds.push("l.created_by = ?");
+    binds.push(query.owner);
+  }
 
   const now = query.now ?? Math.floor(Date.now() / 1000);
   if (query.status === "active") {
@@ -115,12 +124,50 @@ function linkFilterSql(query: Pick<LinkPageQuery, "status" | "search" | "searchO
 }
 
 export class LinkRepository {
-  static async list(db: D1Database, opts?: LinkRepoOptions): Promise<LinkWithSlugs[]> {
-    const links = await db.prepare("SELECT * FROM links ORDER BY created_at DESC").all<Link>();
-    const slugs = await db.prepare(`SELECT ${slugSelect(opts)} FROM slugs s ORDER BY is_custom ASC, created_at ASC`).all<Slug>();
+  /**
+   * Every link matching `query`, newest first, with slugs attached. Two
+   * statements whatever the match count: the rows, then the slugs of those
+   * rows bucketed by `link_id` so assembly stays O(links + slugs).
+   *
+   * The unbounded sibling of `page()`, for the API and MCP callers that hand
+   * back a whole set. Both derive their predicate from `linkFilterSql`, so
+   * what "search" or "owner" selects has one definition: adding a searchable
+   * column or changing case handling reaches every surface at once, and the
+   * two cannot disagree on tie ordering.
+   *
+   * The slug query restates the predicate as a subquery rather than binding
+   * the ids it got back. A match set has no ceiling and D1 caps bound
+   * parameters per statement, so ids cannot be bound here the way `page()`
+   * binds its window. The subquery carries no ORDER BY and no LIMIT, so it
+   * costs a second pass over the predicate and no second sort.
+   */
+  private static async rows(
+    db: D1Database,
+    query: LinkFilterQuery,
+    opts?: LinkRepoOptions,
+  ): Promise<LinkWithSlugs[]> {
+    const { where, binds } = linkFilterSql(query);
+    const links = await db
+      .prepare(`SELECT l.* FROM links l${where} ORDER BY l.created_at DESC, l.id DESC`)
+      .bind(...binds)
+      .all<Link>();
+    const rows = links.results ?? [];
+    if (rows.length === 0) return [];
+
+    // An empty predicate selects every link, so the subquery would filter
+    // nothing and cost a scan to say so.
+    const scope = where ? ` WHERE s.link_id IN (SELECT l.id FROM links l${where})` : "";
+    const slugs = await db
+      .prepare(`SELECT ${slugSelect(opts)} FROM slugs s${scope} ORDER BY is_custom ASC, created_at ASC`)
+      .bind(...(where ? binds : []))
+      .all<Slug>();
 
     const byLink = bucketByLink(slugs.results ?? []);
-    return (links.results ?? []).map((link) => assembleLink(link, byLink.get(link.id) ?? []));
+    return rows.map((link) => assembleLink(link, byLink.get(link.id) ?? []));
+  }
+
+  static async list(db: D1Database, opts?: LinkRepoOptions): Promise<LinkWithSlugs[]> {
+    return LinkRepository.rows(db, {}, opts);
   }
 
   /**
@@ -194,10 +241,7 @@ export class LinkRepository {
    * Rows matching the filters, without fetching any of them. Callers use it to
    * tell an empty catalog from one whose links are all filtered out.
    */
-  static async count(
-    db: D1Database,
-    query?: Pick<LinkPageQuery, "status" | "search" | "searchOwner" | "now">,
-  ): Promise<number> {
+  static async count(db: D1Database, query?: LinkFilterQuery): Promise<number> {
     if (query?.search !== undefined && !query.search.trim()) return 0;
     const { where, binds } = linkFilterSql(query ?? {});
     const row = await db.prepare(`SELECT COUNT(*) AS n FROM links l${where}`).bind(...binds).first<{ n: number }>();
@@ -375,51 +419,25 @@ export class LinkRepository {
     return ((slugRows.results ?? []) as { slug: string }[]).map((r) => r.slug);
   }
 
+  /**
+   * Links whose label, url, any slug, or (with `includeOwner`) `created_by`
+   * contains `query`. Two statements, not one per match: fetching each match
+   * through `getById` cost two statements per row, so a broad search over a
+   * large catalog exhausted D1's per-invocation subrequest budget.
+   */
   static async search(
     db: D1Database,
     query: string,
     opts?: LinkRepoOptions & { includeOwner?: boolean },
   ): Promise<LinkWithSlugs[]> {
+    // A query that trims to nothing matches every row under LIKE, which is the
+    // opposite of what an empty search box means.
     if (!query.trim()) return [];
-
-    const pattern = likePattern(query);
-
-    const where = opts?.includeOwner
-      ? "lower(l.label) LIKE ? ESCAPE '\\' OR lower(s.slug) LIKE ? ESCAPE '\\' OR lower(l.url) LIKE ? ESCAPE '\\' OR lower(l.created_by) LIKE ? ESCAPE '\\'"
-      : "lower(l.label) LIKE ? ESCAPE '\\' OR lower(s.slug) LIKE ? ESCAPE '\\' OR lower(l.url) LIKE ? ESCAPE '\\'";
-
-    const binds = opts?.includeOwner
-      ? [pattern, pattern, pattern, pattern]
-      : [pattern, pattern, pattern];
-
-    const matched = await db
-      .prepare(
-        `SELECT DISTINCT l.id FROM links l
-         LEFT JOIN slugs s ON s.link_id = l.id
-         WHERE ${where}
-         ORDER BY l.created_at DESC`,
-      )
-      .bind(...binds)
-      .all<{ id: number }>();
-
-    const ids = matched.results ?? [];
-    if (ids.length === 0) return [];
-
-    const results = await Promise.all(ids.map(({ id }) => LinkRepository.getById(db, id, opts)));
-    return results.filter((l): l is LinkWithSlugs => l !== null);
+    return LinkRepository.rows(db, { search: query, searchOwner: opts?.includeOwner }, opts);
   }
 
   static async findByOwner(db: D1Database, owner: string, opts?: LinkRepoOptions): Promise<LinkWithSlugs[]> {
-    const rows = await db
-      .prepare("SELECT id FROM links WHERE created_by = ? ORDER BY created_at DESC")
-      .bind(owner)
-      .all<{ id: number }>();
-
-    const ids = rows.results ?? [];
-    if (ids.length === 0) return [];
-
-    const results = await Promise.all(ids.map(({ id }) => LinkRepository.getById(db, id, opts)));
-    return results.filter((l): l is LinkWithSlugs => l !== null);
+    return LinkRepository.rows(db, { owner }, opts);
   }
 
   /**

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -47,7 +47,6 @@ const en = {
   "links.countPlural": "{count} links",
   "links.recent": "Recent",
   "links.popular": "Popular",
-  "links.showDisabled": "Show disabled",
   "links.filterActive": "Active",
   "links.filterDisabled": "Disabled",
   "links.filterAll": "All",
@@ -63,7 +62,8 @@ const en = {
   "links.colTrend": "Trend",
   "links.newLink": "New Link",
   "links.allDisabled":
-    'All links are disabled. Toggle "Show disabled" to see them.',
+    'All links are disabled. Pick the "Disabled" filter to see them.',
+  "links.noMatches": "No links match the current filter.",
   "links.empty": "No links yet. Use the + New Link button above to get started.",
   "links.disabled": "Disabled",
   "links.clicks": "clicks",

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -49,7 +49,6 @@ const id: Translations = {
   "links.countPlural": "{count} tautan",
   "links.recent": "Terbaru",
   "links.popular": "Populer",
-  "links.showDisabled": "Tampilkan nonaktif",
   "links.filterActive": "Aktif",
   "links.filterDisabled": "Nonaktif",
   "links.filterAll": "Semua",
@@ -65,7 +64,8 @@ const id: Translations = {
   "links.colTrend": "Tren",
   "links.newLink": "Tautan Baru",
   "links.allDisabled":
-    'Semua tautan nonaktif. Aktifkan "Tampilkan nonaktif" untuk melihatnya.',
+    'Semua tautan nonaktif. Pilih filter "Nonaktif" untuk melihatnya.',
+  "links.noMatches": "Tidak ada tautan yang cocok dengan filter saat ini.",
   "links.empty":
     "Belum ada tautan. Gunakan tombol + Tautan Baru di atas untuk memulai.",
   "links.disabled": "Nonaktif",

--- a/src/i18n/sv.ts
+++ b/src/i18n/sv.ts
@@ -62,10 +62,10 @@ const sv: Translations = {
   "links.perPage": "per sida",
   "links.perPageAria": "Länkar per sida",
   "links.colTrend": "Trend",
-  "links.showDisabled": "Visa inaktiverade",
   "links.newLink": "Ny länk",
   "links.allDisabled":
-    'Alla länkar är inaktiverade. Växla "Visa inaktiverade" för att se dem.',
+    'Alla länkar är avaktiverade. Välj filtret "Avaktiverade" för att se dem.',
+  "links.noMatches": "Inga länkar matchar det valda filtret.",
   "links.empty":
     "Inga länkar ännu. Använd knappen + Ny länk ovan för att komma igång.",
   "links.disabled": "Inaktiverad",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -226,7 +226,7 @@ app.get("/_/admin/links", async (c) => {
   const rangeParam = c.req.query("range");
   const range = (validRanges.has(rangeParam as TimelineRange) ? rangeParam : defaultRange) as TimelineRange;
   const sort = c.req.query("sort") === "popular" ? "popular" : "recent";
-  const requestedPage = Math.max(1, parseInt(c.req.query("page") || "1", 10) || 1);
+  const requestedPage = parseInt(c.req.query("page") || "1", 10);
   const requestedPerPage = parseInt(c.req.query("per_page") || String(LINKS_DEFAULT_PER_PAGE), 10);
   const filterParam = c.req.query("filter");
   const legacyShowDisabled = c.req.query("show_disabled") === "1";
@@ -236,8 +236,9 @@ app.get("/_/admin/links", async (c) => {
       ? "all"
       : "active";
   // One window, filtered and sorted in SQL: the route pays for the rows it
-  // renders, not for the catalog. listLinksPage clamps page and per_page.
-  const pageResult = await listLinksPage(c.env, {
+  // renders, not for the catalog. The route only parses these params;
+  // listLinksPage owns every bound on page and per_page.
+  const data = await listLinksPage(c.env, {
     page: requestedPage,
     perPage: requestedPerPage,
     sort,
@@ -248,9 +249,6 @@ app.get("/_/admin/links", async (c) => {
     filters,
     range,
   });
-  const data = pageResult.ok
-    ? pageResult.data
-    : { links: [], total: 0, page: 1, perPage: LINKS_DEFAULT_PER_PAGE, totalPages: 1, emptyReason: "no-links" as const };
   return c.html(
     <Layout active="links" theme={theme} t={t} lang={lang} translations={translations}>
       <LinksPage

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,9 +29,8 @@ import {
   getAppSettings,
   resolveClickFilters,
   getLinkAnalytics,
-  listLinks,
+  listLinksPage,
   getLink,
-  searchLinks,
   listAllApiKeys,
   listBundlesForLink,
   listBundles,
@@ -39,7 +38,7 @@ import {
   listBundleLinks,
   getBundleAnalytics,
 } from "./services";
-import { DEFAULT_SLUG_LENGTH, DEFAULT_THEME, THEMES } from "./constants";
+import { DEFAULT_SLUG_LENGTH, DEFAULT_THEME, LINKS_DEFAULT_PER_PAGE, THEMES } from "./constants";
 import { createTranslateFn, getTranslations, DEFAULT_LANGUAGE, isSupportedLanguage } from "./i18n";
 import { handleHealth } from "./api/health";
 import {
@@ -226,13 +225,9 @@ app.get("/_/admin/links", async (c) => {
   const validRanges = new Set<TimelineRange>(["24h", "7d", "30d", "90d", "1y", "all"]);
   const rangeParam = c.req.query("range");
   const range = (validRanges.has(rangeParam as TimelineRange) ? rangeParam : defaultRange) as TimelineRange;
-  const linksResult = searchQuery
-    ? await searchLinks(c.env, searchQuery, { includeOwner: true, withDeltaRange: range, filters, range })
-    : await listLinks(c.env, { withDeltaRange: range, filters, range });
-  const links = linksResult.ok ? linksResult.data : [];
-  const sort = c.req.query("sort") || "recent";
-  const page = Math.max(1, parseInt(c.req.query("page") || "1", 10) || 1);
-  const perPage = Math.max(1, parseInt(c.req.query("per_page") || "25", 10) || 25);
+  const sort = c.req.query("sort") === "popular" ? "popular" : "recent";
+  const requestedPage = Math.max(1, parseInt(c.req.query("page") || "1", 10) || 1);
+  const requestedPerPage = parseInt(c.req.query("per_page") || String(LINKS_DEFAULT_PER_PAGE), 10);
   const filterParam = c.req.query("filter");
   const legacyShowDisabled = c.req.query("show_disabled") === "1";
   const filter = filterParam === "disabled" || filterParam === "all" || filterParam === "active"
@@ -240,13 +235,32 @@ app.get("/_/admin/links", async (c) => {
     : legacyShowDisabled
       ? "all"
       : "active";
+  // One window, filtered and sorted in SQL: the route pays for the rows it
+  // renders, not for the catalog. listLinksPage clamps page and per_page.
+  const pageResult = await listLinksPage(c.env, {
+    page: requestedPage,
+    perPage: requestedPerPage,
+    sort,
+    status: filter,
+    search: searchQuery || undefined,
+    includeOwner: true,
+    withDeltaRange: range,
+    filters,
+    range,
+  });
+  const data = pageResult.ok
+    ? pageResult.data
+    : { links: [], total: 0, page: 1, perPage: LINKS_DEFAULT_PER_PAGE, totalPages: 1, emptyReason: "no-links" as const };
   return c.html(
     <Layout active="links" theme={theme} t={t} lang={lang} translations={translations}>
       <LinksPage
-        links={links}
+        links={data.links}
+        total={data.total}
+        totalPages={data.totalPages}
+        emptyReason={data.emptyReason}
         sort={sort}
-        page={page}
-        perPage={perPage}
+        page={data.page}
+        perPage={data.perPage}
         filter={filter}
         range={range}
         searchQuery={searchQuery}

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -7,6 +7,8 @@ import type { TranslateFn } from "../i18n";
 import { Delta } from "../components/delta";
 import { RangePicker } from "../components/range-picker";
 import { fmtNumber } from "../i18n/format";
+import { LINKS_DEFAULT_PER_PAGE, LINKS_PER_PAGE_OPTIONS } from "../constants";
+import type { LinksEmptyReason } from "../services/link-management";
 
 function formatDate(ts: number, lang: string): string {
   const d = new Date(ts * 1000);
@@ -62,7 +64,16 @@ export function paginationItems(
 }
 
 type Props = {
+  /**
+   * Rows for the current page only: the query already applied the filter, the
+   * sort and the window, so this component never slices a catalog.
+   */
   links: LinkWithSlugs[];
+  /** Rows matching the filter across the whole catalog. Drives the counts. */
+  total: number;
+  totalPages: number;
+  /** Set only when `links` is empty; picks which empty-state copy to show. */
+  emptyReason?: LinksEmptyReason;
   sort: string;
   page: number;
   perPage: number;
@@ -75,6 +86,9 @@ type Props = {
 
 export const LinksPage: FC<Props> = ({
   links,
+  total,
+  totalPages,
+  emptyReason,
   sort,
   page,
   perPage,
@@ -88,25 +102,8 @@ export const LinksPage: FC<Props> = ({
   const isLinkDisabled = (l: LinkWithSlugs) =>
     l.expires_at != null && l.expires_at < now;
 
-  const activeLinks = links.filter((l) => !isLinkDisabled(l));
-  const disabledLinks = links.filter((l) => isLinkDisabled(l));
-  const filtered =
-    filter === "disabled"
-      ? disabledLinks
-      : filter === "all"
-        ? links
-        : activeLinks;
-
-  const sorted = [...filtered].sort((a, b) =>
-    sort === "popular"
-      ? b.total_clicks - a.total_clicks
-      : b.created_at - a.created_at,
-  );
-
-  const totalPages = Math.max(1, Math.ceil(sorted.length / perPage));
-  const currentPage = Math.min(page, totalPages);
+  const currentPage = Math.min(Math.max(1, page), totalPages);
   const start = (currentPage - 1) * perPage;
-  const pageLinks = sorted.slice(start, start + perPage);
 
   function buildUrl(overrides: Record<string, string | undefined>): string {
     const params = new URLSearchParams();
@@ -129,7 +126,7 @@ export const LinksPage: FC<Props> = ({
   const perPageUrl = (n: number) => buildUrl({ per_page: String(n), page: "1" });
   const filterUrl = (f: LinksFilter) => buildUrl({ filter: f, page: "1" });
 
-  const countKey = filtered.length !== 1 ? "links.countPlural" : "links.count";
+  const countKey = total !== 1 ? "links.countPlural" : "links.count";
 
   const filterChips: { key: LinksFilter; labelKey: "links.filterActive" | "links.filterDisabled" | "links.filterAll"; icon: string }[] = [
     { key: "active", labelKey: "links.filterActive", icon: "link" },
@@ -173,7 +170,7 @@ export const LinksPage: FC<Props> = ({
 
       {searchQuery && (
         <div class="search-results-bar">
-          <span class="count">{t("links.searchResults", { count: filtered.length })}</span>
+          <span class="count">{t("links.searchResults", { count: total })}</span>
           <a href="/_/admin/links" class="btn btn-ghost btn-sm">
             <span class="icon icon-xs">close</span> {t("links.clearSearch")}
           </a>
@@ -210,16 +207,16 @@ export const LinksPage: FC<Props> = ({
             </a>
           </div>
           <div class="toolbar-count">
-            {t(countKey as any, { count: filtered.length })}
+            {t(countKey as any, { count: total })}
           </div>
         </div>
       </div>
 
-      {filtered.length === 0 ? (
+      {links.length === 0 ? (
         <div class="empty-state">
           <span class="icon">link_off</span>
           <p>
-            {links.length > 0
+            {emptyReason === "all-filtered"
               ? t("links.allDisabled")
               : t("links.empty")}
           </p>
@@ -238,7 +235,7 @@ export const LinksPage: FC<Props> = ({
                   </tr>
                 </thead>
                 <tbody>
-                  {pageLinks.map((link) => {
+                  {links.map((link) => {
                     const mainSlug = link.slugs.find((s) => s.is_primary)
                       || link.slugs.find((s) => s.is_custom)
                       || link.slugs[0];
@@ -300,13 +297,13 @@ export const LinksPage: FC<Props> = ({
             </div>
           </div>
 
-          {(totalPages > 1 || links.length > 25) && (
+          {(totalPages > 1 || total > LINKS_DEFAULT_PER_PAGE) && (
             <div class="pagination">
               <div class="pagination-summary">
                 {t("links.pageSummary", {
-                  from: sorted.length === 0 ? 0 : start + 1,
-                  to: Math.min(start + perPage, sorted.length),
-                  total: sorted.length,
+                  from: total === 0 ? 0 : start + 1,
+                  to: Math.min(start + perPage, total),
+                  total,
                 })}
               </div>
               <div class="pagination-pages">
@@ -348,7 +345,7 @@ export const LinksPage: FC<Props> = ({
                     onchange="location.href=this.value"
                     aria-label={t("links.perPageAria")}
                   >
-                    {[25, 50, 100].map((n) => (
+                    {LINKS_PER_PAGE_OPTIONS.map((n) => (
                       <option value={perPageUrl(n)} selected={perPage === n}>
                         {n}
                       </option>

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -8,7 +8,7 @@ import { Delta } from "../components/delta";
 import { RangePicker } from "../components/range-picker";
 import { fmtNumber } from "../i18n/format";
 import { LINKS_PER_PAGE_OPTIONS } from "../constants";
-import type { LinksEmptyReason } from "../services/link-management";
+import type { LinksEmptyReason } from "../services";
 
 function formatDate(ts: number, lang: string): string {
   const d = new Date(ts * 1000);

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -23,6 +23,25 @@ export type LinksFilter = "active" | "disabled" | "all";
 
 export type PaginationItem = number | "ellipsis";
 
+/**
+ * The page actually rendered and where its rows start, with every input
+ * floored the way `paginationItems` floors its own. Clamp here rather than at
+ * the call site: a caller computing `Math.ceil(0 / perPage)` hands over
+ * `totalPages: 0`, which drives `currentPage` to 0 and the row range to
+ * `-perPage`. The upper bound on `perPage` stays with the service, which owns
+ * `LINKS_MAX_PER_PAGE`.
+ */
+export function pageWindow(
+  page: number,
+  perPage: number,
+  totalPages: number,
+): { currentPage: number; pageCount: number; perPage: number; start: number } {
+  const rows = Math.max(1, Math.floor(perPage) || 1);
+  const pageCount = Math.max(1, Math.floor(totalPages) || 1);
+  const currentPage = Math.min(Math.max(1, Math.floor(page) || 1), pageCount);
+  return { currentPage, pageCount, perPage: rows, start: (currentPage - 1) * rows };
+}
+
 export function paginationItems(
   currentPage: number,
   totalPages: number,
@@ -102,15 +121,14 @@ export const LinksPage: FC<Props> = ({
   const isLinkDisabled = (l: LinkWithSlugs) =>
     l.expires_at != null && l.expires_at < now;
 
-  const currentPage = Math.min(Math.max(1, page), totalPages);
-  const start = (currentPage - 1) * perPage;
+  const { currentPage, pageCount, perPage: rowsPerPage, start } = pageWindow(page, perPage, totalPages);
 
   function buildUrl(overrides: Record<string, string | undefined>): string {
     const params = new URLSearchParams();
     const next = {
       sort,
       page: String(currentPage),
-      per_page: String(perPage),
+      per_page: String(rowsPerPage),
       filter,
       range,
       search: searchQuery,
@@ -140,7 +158,7 @@ export const LinksPage: FC<Props> = ({
     sort,
     filter,
     page: String(currentPage),
-    per_page: String(perPage),
+    per_page: String(rowsPerPage),
   };
   if (searchQuery) preserveParams.search = searchQuery;
 
@@ -302,11 +320,11 @@ export const LinksPage: FC<Props> = ({
             <div class="pagination-summary">
               {t("links.pageSummary", {
                 from: total === 0 ? 0 : start + 1,
-                to: Math.min(start + perPage, total),
+                to: Math.min(start + rowsPerPage, total),
                 total,
               })}
             </div>
-            {totalPages > 1 && (
+            {pageCount > 1 && (
               <div class="pagination-pages">
                 <a
                   class={`page-btn${currentPage <= 1 ? " disabled" : ""}`}
@@ -314,7 +332,7 @@ export const LinksPage: FC<Props> = ({
                 >
                   <span class="icon icon-sm">chevron_left</span>
                 </a>
-                {paginationItems(currentPage, totalPages).map((item) =>
+                {paginationItems(currentPage, pageCount).map((item) =>
                   item === "ellipsis" ? (
                     <span class="page-ellipsis" aria-hidden="true">…</span>
                   ) : (
@@ -328,9 +346,9 @@ export const LinksPage: FC<Props> = ({
                   ),
                 )}
                 <a
-                  class={`page-btn${currentPage >= totalPages ? " disabled" : ""}`}
+                  class={`page-btn${currentPage >= pageCount ? " disabled" : ""}`}
                   href={
-                    currentPage < totalPages
+                    currentPage < pageCount
                       ? pageUrl(currentPage + 1)
                       : "#"
                   }
@@ -348,7 +366,7 @@ export const LinksPage: FC<Props> = ({
                   aria-label={t("links.perPageAria")}
                 >
                   {LINKS_PER_PAGE_OPTIONS.map((n) => (
-                    <option value={perPageUrl(n)} selected={perPage === n}>
+                    <option value={perPageUrl(n)} selected={rowsPerPage === n}>
                       {n}
                     </option>
                   ))}

--- a/src/pages/links.tsx
+++ b/src/pages/links.tsx
@@ -235,9 +235,11 @@ export const LinksPage: FC<Props> = ({
         <div class="empty-state">
           <span class="icon">link_off</span>
           <p>
-            {emptyReason === "all-filtered"
+            {emptyReason === "all-disabled"
               ? t("links.allDisabled")
-              : t("links.empty")}
+              : emptyReason === "no-matches"
+                ? t("links.noMatches")
+                : t("links.empty")}
           </p>
         </div>
       ) : (

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,6 +3,7 @@
 
 export {
   listLinks,
+  listLinksPage,
   getLink,
   getLinkBySlug,
   createLink,
@@ -18,6 +19,12 @@ export {
   listLinksByOwner,
   findSlugForRedirect,
   recordClick,
+} from "./link-management";
+export type {
+  ListLinksOptions,
+  ListLinksPageOptions,
+  LinksPageData,
+  LinksEmptyReason,
 } from "./link-management";
 
 export {

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -20,12 +20,7 @@ export {
   findSlugForRedirect,
   recordClick,
 } from "./link-management";
-export type {
-  ListLinksOptions,
-  ListLinksPageOptions,
-  LinksPageData,
-  LinksEmptyReason,
-} from "./link-management";
+export type { LinksEmptyReason } from "./link-management";
 
 export {
   listAllApiKeys,

--- a/src/services/link-management.ts
+++ b/src/services/link-management.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LinkRepository, SlugRepository, ClickRepository, SettingRepository } from "../db";
-import type { ClickFilters } from "../db";
+import type { ClickFilters, LinkSort, LinkStatus } from "../db";
 import { SlugCache } from "../kv";
-import { DEFAULT_SLUG_LENGTH } from "../constants";
+import { DEFAULT_SLUG_LENGTH, LINKS_DEFAULT_PER_PAGE, LINKS_MAX_PER_PAGE } from "../constants";
 import { generateUniqueSlug, validateSlugLength, validateCustomSlug } from "../slugs";
 import { BreakdownPage, ClickData, ClickStats, DashboardStats, Env, LinkWithSlugs, Slug, TimelineData, TimelineRange } from "../types";
 import { normalizeUrl } from "../normalize-url";
@@ -46,6 +46,85 @@ export async function listLinks(env: Env, opts?: ListLinksOptions): Promise<Serv
   if (!opts?.withDeltaRange) return ok(links);
   const enriched = await ClickRepository.attachLinkDeltasBulk(env.DB, links, opts.withDeltaRange, undefined, opts.filters);
   return ok(enriched);
+}
+
+export interface ListLinksPageOptions extends ListLinksOptions {
+  /** 1-based. Clamped up to 1 and down to the last populated page. */
+  page?: number;
+  /** Clamped to [1, LINKS_MAX_PER_PAGE]. */
+  perPage?: number;
+  sort?: LinkSort;
+  status?: LinkStatus;
+  /** Substring filter. Omit for the unsearched listing; a blank string matches nothing. */
+  search?: string;
+  /** Widen the search to created_by. Admin surfaces only. */
+  includeOwner?: boolean;
+}
+
+/** Why a rendered page has no rows, so the caller can pick the right empty copy. */
+export type LinksEmptyReason = "no-links" | "all-filtered";
+
+export interface LinksPageData {
+  /** Rows for this page: already filtered, sorted and windowed by SQL. */
+  links: LinkWithSlugs[];
+  /** Rows matching the filters across the whole catalog. */
+  total: number;
+  /** Page actually served, after clamping. */
+  page: number;
+  perPage: number;
+  totalPages: number;
+  /** Set only when `links` is empty. */
+  emptyReason?: LinksEmptyReason;
+}
+
+/**
+ * One page of the links listing. Cost scales with `perPage`, not with the
+ * catalog: SQL does the filtering, sorting and windowing, and only the served
+ * rows get delta enrichment. Use this for the listings page; `listLinks`
+ * remains for API and MCP callers that return the full set.
+ */
+export async function listLinksPage(env: Env, opts?: ListLinksPageOptions): Promise<ServiceResult<LinksPageData>> {
+  const perPage = Math.min(
+    Math.max(1, Math.floor(opts?.perPage ?? LINKS_DEFAULT_PER_PAGE) || LINKS_DEFAULT_PER_PAGE),
+    LINKS_MAX_PER_PAGE,
+  );
+  const requestedPage = Math.max(1, Math.floor(opts?.page ?? 1) || 1);
+  const status = opts?.status ?? "active";
+  const sinceTs = rangeToSinceTs(opts?.range);
+
+  const result = await LinkRepository.page(
+    env.DB,
+    {
+      limit: perPage,
+      offset: (requestedPage - 1) * perPage,
+      sort: opts?.sort ?? "recent",
+      status,
+      search: opts?.search,
+      searchOwner: opts?.includeOwner,
+    },
+    { filters: opts?.filters, sinceTs },
+  );
+
+  const totalPages = Math.max(1, Math.ceil(result.total / perPage));
+  // The repository clamps an out-of-range offset, so derive the served page
+  // from what came back rather than from what was asked for.
+  const page = Math.floor(result.offset / perPage) + 1;
+
+  let emptyReason: LinksEmptyReason | undefined;
+  if (result.total === 0) {
+    // One extra count, only on the empty path: it separates "no links yet"
+    // from "the status filter hid them all".
+    const unfiltered = status === "all"
+      ? 0
+      : await LinkRepository.count(env.DB, { search: opts?.search, searchOwner: opts?.includeOwner });
+    emptyReason = unfiltered > 0 ? "all-filtered" : "no-links";
+  }
+
+  const links = opts?.withDeltaRange
+    ? await ClickRepository.attachLinkDeltasBulk(env.DB, result.links, opts.withDeltaRange, undefined, opts.filters)
+    : result.links;
+
+  return ok({ links, total: result.total, page, perPage, totalPages, emptyReason });
 }
 
 export interface GetLinkOptions {

--- a/src/services/link-management.ts
+++ b/src/services/link-management.ts
@@ -61,8 +61,13 @@ export interface ListLinksPageOptions extends ListLinksOptions {
   includeOwner?: boolean;
 }
 
-/** Why a rendered page has no rows, so the caller can pick the right empty copy. */
-export type LinksEmptyReason = "no-links" | "all-filtered";
+/**
+ * Why a rendered page has no rows, so the caller can pick the right empty copy.
+ * `no-links` means the catalog itself is empty, `all-disabled` that every link
+ * there is has expired, and `no-matches` that the search or status filter
+ * selected none of them.
+ */
+export type LinksEmptyReason = "no-links" | "all-disabled" | "no-matches";
 
 export interface LinksPageData {
   /** Rows for this page: already filtered, sorted and windowed by SQL. */
@@ -73,7 +78,7 @@ export interface LinksPageData {
   page: number;
   perPage: number;
   totalPages: number;
-  /** Set only when `links` is empty. */
+  /** Set whenever `links` is empty, which is when the caller renders empty copy. */
   emptyReason?: LinksEmptyReason;
 }
 
@@ -110,14 +115,21 @@ export async function listLinksPage(env: Env, opts?: ListLinksPageOptions): Prom
   // from what came back rather than from what was asked for.
   const page = Math.floor(result.offset / perPage) + 1;
 
+  // Keyed off the served window, not the total: the two come from separate
+  // statements, so a positive total can arrive with nothing to render and the
+  // page would print a row count directly above "no links yet".
   let emptyReason: LinksEmptyReason | undefined;
-  if (result.total === 0) {
-    // One extra count, only on the empty path: it separates "no links yet"
-    // from "the status filter hid them all".
-    const unfiltered = status === "all"
-      ? 0
-      : await LinkRepository.count(env.DB, { search: opts?.search, searchOwner: opts?.includeOwner });
-    emptyReason = unfiltered > 0 ? "all-filtered" : "no-links";
+  if (result.links.length === 0) {
+    // One extra count, only on the empty path, and unfiltered: it is the one
+    // thing the rows cannot say, whether the catalog is empty or the filters
+    // emptied it.
+    const catalog = await LinkRepository.count(env.DB);
+    if (catalog === 0) emptyReason = "no-links";
+    // Nothing active in a non-empty catalog means every link has expired.
+    // Any other empty result is a filter or search that selected none of them,
+    // which is the opposite claim.
+    else if (status === "active" && !opts?.search?.trim()) emptyReason = "all-disabled";
+    else emptyReason = "no-matches";
   }
 
   const links = opts?.withDeltaRange

--- a/src/services/link-management.ts
+++ b/src/services/link-management.ts
@@ -87,8 +87,12 @@ export interface LinksPageData {
  * catalog: SQL does the filtering, sorting and windowing, and only the served
  * rows get delta enrichment. Use this for the listings page; `listLinks`
  * remains for API and MCP callers that return the full set.
+ *
+ * Returns the page data rather than a `ServiceResult`: every input is clamped
+ * here, so there is no failure to report and no caller has to write a fallback
+ * arm that restates the shape.
  */
-export async function listLinksPage(env: Env, opts?: ListLinksPageOptions): Promise<ServiceResult<LinksPageData>> {
+export async function listLinksPage(env: Env, opts?: ListLinksPageOptions): Promise<LinksPageData> {
   const perPage = Math.min(
     Math.max(1, Math.floor(opts?.perPage ?? LINKS_DEFAULT_PER_PAGE) || LINKS_DEFAULT_PER_PAGE),
     LINKS_MAX_PER_PAGE,
@@ -136,7 +140,7 @@ export async function listLinksPage(env: Env, opts?: ListLinksPageOptions): Prom
     ? await ClickRepository.attachLinkDeltasBulk(env.DB, result.links, opts.withDeltaRange, undefined, opts.filters)
     : result.links;
 
-  return ok({ links, total: result.total, page, perPage, totalPages, emptyReason });
+  return { links, total: result.total, page, perPage, totalPages, emptyReason };
 }
 
 export interface GetLinkOptions {


### PR DESCRIPTION
Closes [#45](https://github.com/oddbit/shrtnr/issues/45).

## What was happening

`/_/admin/links` read the whole catalog on every request. `LinkRepository.list` ran an unbounded `SELECT * FROM links` plus an unbounded slug query, then rescanned the full slug set once per link, so assembly was O(links x slugs). `listLinks` handed the entire result to `ClickRepository.attachLinkDeltasBulk`, which computed a delta for every row. `LinksPage` then filtered, sorted and sliced 25 rows out in JSX. At 4,700 links that is 4,700 rows and 4,700 delta computations to render 25.

The search path on the same route was worse: `LinkRepository.search` fanned out one `getById` per match, so a broad search spent a subrequest per matching link.

## What changed

`LinkRepository.page()` puts the window in SQL. Three statements whatever the catalog size:

1. `count()` for the total the page was cut from, which is what `totalPages` needs. `page()` calls it rather than building a second `COUNT`, so the toolbar total and the empty-state count cannot diverge.
2. The windowed link rows: `LIMIT ? OFFSET ?`.
3. The slugs of only those rows, bound to the ids the window returned and bucketed into a `Map` keyed by `link_id` so assembly is O(links + slugs).

Sorting and the active/disabled filter moved into the query, since neither can run in JS once the page holds a slice. Popular ordering reuses the same click filters and `sinceTs` as the rendered `click_count`: both count fragments append one shared `clickWindowSql`, so the ranking and the printed numbers cannot drift apart.

`migrations/0007` adds `idx_links_created_at ON links(created_at DESC, id DESC)`. Without it the windowed query still reported `SCAN l | USE TEMP B-TREE FOR ORDER BY`, so SQLite read and sorted the whole table to hand back 25 rows and the route kept paying for the catalog. The index lets the planner walk in order and stop after `limit + offset` rows. A plan test asserts the temp B-tree is gone and fails if the migration is removed.

`LinkRepository.rows()` is the unbounded sibling of `page()`, for the API and MCP callers that return whole sets. `list`, `search`, `findByOwner` and `findByUrl` all delegate to it, and all four derive their predicate from the same `linkFilterSql` that `page()` uses. That gives search, owner and status one SQL definition instead of two divergent ones, and it removes the `Promise.all(ids.map(getById))` fan-out from every caller, not just the admin page. Each costs two statements whatever the match count.

`attachLinkDeltasBulk` now restricts its group-by to the ids it was handed. Clicks outgrow links, so grouping every click in the range to label 25 rows was the largest scan left in the request. The two window bounds moved inline, the way `clickWindowSql` already inlines `sinceTs`, which frees the whole parameter budget for ids and lets a full 100-row page stay inside it. Past the cap the ids will not bind and a caller passing the whole catalog wants the full aggregate anyway, so that path keeps the unrestricted query.

`listLinksPage()` owns the page arithmetic and every bound on `page` and `per_page`; the route only parses them. It returns `LinksPageData` rather than a `ServiceResult`, since it clamps every input and has no failure to report. `perPage` clamps to `[1, LINKS_MAX_PER_PAGE]`, which is now derived from `LINKS_PER_PAGE_OPTIONS` and pinned under `D1_MAX_BOUND_PARAMS` by a test, so growing the selector cannot outrun the slug query's binds. An out-of-range `page` still lands on the last populated window.

`LinksPage` became presentational. It receives the rows it renders plus `total`, `totalPages` and `emptyReason`, and `pageWindow()` floors all three page inputs the way `paginationItems` already floored its own. `emptyReason` carries the one thing the component cannot see for itself, and it now has three cases rather than two: `no-links`, `all-disabled` and `no-matches`. The service picks between them from an unfiltered catalog count, keyed off the served window rather than the total.

## Behavior

Query params, URLs and copy are unchanged, legacy `show_disabled=1` included. Four deliberate differences:

- **Tie ordering on the API and MCP surfaces changes, and the index is what changes it.** With three links sharing a `created_at` second: pre-branch `ORDER BY created_at DESC` planned as `SCAN links | USE TEMP B-TREE FOR ORDER BY` and returned them oldest first; with `idx_links_created_at` the same SQL plans as an index walk and returns them newest first. The explicit `created_at DESC, id DESC` does not introduce that flip, it pins it. Without the tie-break the index would have reordered API and MCP results with nothing in the code saying so, and it would flip back the day the planner stops choosing that index. Nothing depends on the ordering: the spec's only ordering promise is `BreakdownPage.items`, no SDK README or MCP tool description mentions link ordering, and `GET /api/links` takes only `owner` and `range` with no limit/offset, so unstable ties were producing nondeterministic output rather than corrupting pagination. Observable only for links created in the same second.
- `?filter=disabled` on an all-active catalog used to render "All links are disabled. Toggle Show disabled to see them." It now renders "No links match the current filter." The old copy stated the inverse of the truth and named a toggle the filter chips replaced; the dead `links.showDisabled` key is gone from all three locales.
- `per_page` above 100 clamps to 100. Previously it was unbounded.
- An unrecognized `sort` value now renders as `recent` and marks that chip active, instead of marking neither.

## Tests

38 repository cases across `link-page` (windowing, ordering, the status filter, search, counts, one statement-count test pinning three statements at 5 links and at 60, one asserting the window is computed once), `link-query-cost` (two statements per call for `list`, `search`, `findByOwner` and `findByUrl` at 3 matches and at 40) and `link-page-plan` (the index walk). 14 service cases for clamping, page arithmetic and the three empty reasons. 35 page cases asserting the route renders one window, pages the filtered set, and never claims every link is disabled when none is. 19 unit cases for the page window, the per-page bounds and the shared click-count tail. Full suite: 83 files, 1235 tests, all passing. `tsc --noEmit` clean. `./scripts/spec-hash.sh` matches the three recorded SDK hashes, so no spec drift and no SDK work.

## Follow-ups left alone

Sequencing against the admin widget-island migration, as the issue notes, is untouched: the page is now a pure function of a served window, which is the shape an htmx partial wants.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RApYtwk8yHbC9UNAm4ehMX)_
