### PR TITLE
Weekly defect review: fix dev-login open-redirect bypass

### DIFF
--- a/src/__tests__/handler/dev-login.test.ts
+++ b/src/__tests__/handler/dev-login.test.ts
@@ -35,6 +35,17 @@ describe("GET /_/dev/login (dev mode)", () => {
     }
   });
 
+  it("rejects a `to` that only looks same-origin because of an embedded tab/CR/LF", async () => {
+    // A browser strips embedded TAB/CR/LF from a URL before parsing it, so `/\t/evil.example`
+    // collapses to the scheme-relative `//evil.example` once the redirect is followed, even
+    // though it passes a naive `startsWith("/") && !startsWith("//")` check.
+    for (const to of ["/\t/evil.example", "/\r/evil.example", "/\n/evil.example", "/\t\t//evil.example"]) {
+      const res = await SELF.fetch(req(`/_/dev/login?as=alice@example.com&to=${encodeURIComponent(to)}`));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("Location")).toBe("/_/admin/dashboard");
+    }
+  });
+
   it("renders a form when no identity is given", async () => {
     const res = await SELF.fetch(req("/_/dev/login"));
     expect(res.status).toBe(200);

--- a/src/dev-login.ts
+++ b/src/dev-login.ts
@@ -27,9 +27,17 @@ function isDevMode(env: Env): boolean {
   return !env.ACCESS_AUD;
 }
 
-/** Same-origin path only. Anything that could leave the origin falls back to the dashboard. */
+/**
+ * Same-origin path only. Anything that could leave the origin falls back to the dashboard.
+ *
+ * Browsers strip embedded TAB/CR/LF from a URL before parsing it (the WHATWG URL spec's
+ * "remove all ASCII tab or newline" step), so `/\t/evil.example` looks same-origin here but
+ * resolves to `//evil.example`, a scheme-relative URL, once the browser follows the redirect.
+ * Apply the same stripping before validating, so the check sees what the browser will see.
+ */
 function safeReturnPath(raw: string | null): string {
-  if (raw && raw.startsWith("/") && !raw.startsWith("//") && !raw.startsWith("/\\")) return raw;
+  const stripped = raw?.replace(/[\t\r\n]/g, "") ?? "";
+  if (stripped.startsWith("/") && !stripped.startsWith("//") && !stripped.startsWith("/\\")) return stripped;
   return "/_/admin/dashboard";
 }
 


### PR DESCRIPTION
Weekly defect-hunting review of the app, API, and SDKs. One qualifying defect fixed; several items flagged below for developer judgment (not changed in this diff).

## Fixed

### Open-redirect bypass in `dev-login.ts` `safeReturnPath()`

**What was wrong:** the `to=` return-path check rejected values starting with `//` or `/\` but did not strip embedded TAB/CR/LF first. The WHATWG URL spec removes those characters before parsing a URL, so `to=/\t/evil.example` passes the same-origin check (`startsWith("/")`, not `//`, not `/\`) but a browser resolves it to `//evil.example`, a scheme-relative URL, once it follows the `Location` header.

**Impact:** an attacker-crafted dev-login link logs a browser in under an attacker-chosen identity, sets the session cookie, then bounces the browser off the trusted origin to an arbitrary external site (phishing). Scope is limited: both `/_/dev/*` handlers 404 whenever `ACCESS_AUD` is set, so this is only reachable in local/dev deployments or a misconfigured environment without Cloudflare Access — never in a correctly configured production deployment. Still a real bug in code that ships in the repository.

**Fix:** `safeReturnPath()` now strips TAB/CR/LF before running the same-origin checks, so the check sees the path a browser will actually resolve (`src/dev-login.ts`).

**Test:** added `rejects a \`to\` that only looks same-origin because of an embedded tab/CR/LF` to `src/__tests__/handler/dev-login.test.ts`, covering tab, CR, LF, and a combined variant. Verified it fails against the prior code and passes with the fix. Full suite: 86 test files / 1285 tests green.

## Flagged for developer judgment (not changed)

1. **Dart SDK: `Bundle.accent` / `TimelineData.range` silently default instead of raising on a missing/null value** (`sdk/dart/lib/src/models.dart:335,433,779`). The Python SDK deliberately hardened the same case — `Bundle.from_dict`/`BundleWithSummary.from_dict` now raise `KeyError` on a missing `accent` instead of defaulting to `"orange"` (see `sdk/python/CHANGELOG.md`, tests at `sdk/python/tests/test_client.py:685,703`) — but Dart still defaults, and has its own tests (`sdk/dart/test/client_test.dart:1182,~1247-1327`) asserting the default as intended behavior. Both fields are non-optional in the OpenAPI schema. This is a genuine SDK-parity divergence in error-handling philosophy for a required field, but fixing it means changing Dart's public parsing behavior (default → throw) and rewriting the existing tests that assert the default, which is outside what this pass fixes directly. No live exploit path today (`bundles.accent` is `NOT NULL DEFAULT 'orange'` in the DB), but worth a deliberate decision: align Dart with Python's fix, or explicitly document why Dart differs.

2. **`browser-extensions/package.json` pins `@oddbit/shrtnr` behind the SDK's own recent bugfix releases.** Declared as `^1.1.0`, but `yarn.lock` resolves exactly `1.1.0` while `sdk/typescript/package.json` is at `1.1.4`. The gap covers three real bug fixes documented in `sdk/typescript/CHANGELOG.md`: 1.1.1 (crash on a custom `fetch`), 1.1.2 (`Date`/`Map`/`URL` request bodies silently serializing to `{}`), 1.1.3/1.1.4 (a connection reset mid-response mislabeled with the wrong HTTP status). These are within the declared `^1.1.0` range, so a lockfile refresh (`yarn install` in `browser-extensions/`) would pick them up without a manifest change. Not applied here since these are bug fixes, not security patches, per this review's fix-vs-flag criteria.

3. **`browser-extensions` dependency refresh has drifted a cadence behind the rest of the repo.** The 2026-07-28 dependency sweep (commits `faa8bf4`, `ecaf89e`, `dd7b199`, `ec82be0`) refreshed root, the TypeScript SDK, the Python SDK, and the Dart SDK, but not `browser-extensions` — it's still on the 2026-06-28 sweep (`fac34ab`). One visible symptom: `vitest ^4.1.9` there vs `^4.1.10` everywhere else. Worth checking current advisories for `esbuild@0.28.1` and `web-ext@10.4.0` given the extra staleness window; no specific CVE confirmed.

4. **Historical migration `0004_slug_text_pk.sql` backs up `clicks` via `INNER JOIN slugs`, not `LEFT JOIN`.** Any `clicks` row whose `slug_id` didn't match a `slugs.id` at migration time would have been silently dropped, with no row-count check. This migration already ran; nothing to change in the diff. Flagging as a pattern for future table-recreation migrations: use `LEFT JOIN` plus an explicit before/after row-count assertion, per `CLAUDE.md`'s migration rules. (`src/db/slug-repository.ts:141-143` already documents the team's own uncertainty about whether D1 enforces the `ON DELETE CASCADE` this migration guards against.)

5. **Dead code, latent trap:** `src/client.ts:213-273` (`showCreateModal`/`createLink`) has no call site anywhere in the codebase and reads a nonexistent DOM id (`slug-length-default`; the real one is `slug-length-input`). No current user impact since nothing invokes it, but whoever next wires a "New Link" button to it will silently always get slug length `3` regardless of the configured default. Not removed here since dead-code cleanup is outside this review's defect-fixing scope; flagging so it doesn't quietly get reactivated.

## Review scope

Four parallel passes covered: core API/router/auth/redirect/db layer, admin UI/i18n/client-side JS, all three SDKs (spec-hash and cross-SDK parity), and dependency/migration drift. No other concrete, evidence-backed defects were found in any of those passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184EEyS4TwPZi5SceQQmuSg

---
_Generated by [Claude Code](https://claude.ai/code/session_0184EEyS4TwPZi5SceQQmuSg)_