### PR TITLE
Weekly review batch: silent custom-slug failure, unsafe client-side interpolation, Python SDK InvalidURL escape, slug-repository invariant guard, unscannable QR codes, title-fetch SSRF guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^26.4.0",
     "@vitest/runner": "^4.1.11",
     "@vitest/snapshot": "^4.1.11",
+    "jsqr": "1.4.0",
     "tsx": "^4.23.12",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11",

--- a/sdk/python/src/shrtnr/resources/bundles.py
+++ b/sdk/python/src/shrtnr/resources/bundles.py
@@ -54,9 +54,12 @@ class Bundles:
         return _build_url(self._base_url, path, query)
 
     def _request(self, method: str, url: str, **kwargs: Any) -> Any:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_json_response(response)
 
@@ -199,9 +202,12 @@ class AsyncBundles:
         return _build_url(self._base_url, path, query)
 
     async def _request(self, method: str, url: str, **kwargs: Any) -> Any:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = await self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_json_response(response)
 

--- a/sdk/python/src/shrtnr/resources/links.py
+++ b/sdk/python/src/shrtnr/resources/links.py
@@ -52,16 +52,22 @@ class Links:
         return _build_url(self._base_url, path, query)
 
     def _request(self, method: str, url: str, **kwargs: Any) -> Any:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_json_response(response)
 
     def _request_text(self, method: str, url: str, **kwargs: Any) -> str:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_text_response(response)
 
@@ -206,16 +212,22 @@ class AsyncLinks:
         return _build_url(self._base_url, path, query)
 
     async def _request(self, method: str, url: str, **kwargs: Any) -> Any:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = await self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_json_response(response)
 
     async def _request_text(self, method: str, url: str, **kwargs: Any) -> str:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = await self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_text_response(response)
 

--- a/sdk/python/src/shrtnr/resources/slugs.py
+++ b/sdk/python/src/shrtnr/resources/slugs.py
@@ -37,9 +37,12 @@ class Slugs:
         return _build_url(self._base_url, path)
 
     def _request(self, method: str, url: str, **kwargs: Any) -> Any:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_json_response(response)
 
@@ -89,9 +92,12 @@ class AsyncSlugs:
         return _build_url(self._base_url, path)
 
     async def _request(self, method: str, url: str, **kwargs: Any) -> Any:
+        # httpx.InvalidURL isn't a RequestError subclass; catch it too so a
+        # malformed base_url raises ShrtnrError(0, ...) like any other request
+        # failure, per this SDK's documented contract.
         try:
             response = await self._http.request(method, url, **kwargs)
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, httpx.InvalidURL) as exc:
             raise ShrtnrError(0, str(exc)) from exc
         return parse_json_response(response)
 

--- a/sdk/python/tests/test_async_client.py
+++ b/sdk/python/tests/test_async_client.py
@@ -92,6 +92,17 @@ async def test_async_network_error_wraps_as_status_0(client: AsyncShrtnr) -> Non
         assert exc_info.value.status == 0
 
 
+async def test_async_malformed_base_url_wraps_as_status_0() -> None:
+    # httpx.InvalidURL (e.g. a bad port) is raised synchronously from
+    # request-building, before any I/O, and is not a subclass of
+    # httpx.RequestError. It must still surface as the documented
+    # ShrtnrError(status=0, ...), not escape as a raw httpx exception.
+    client = AsyncShrtnr(base_url="https://example.com:notaport", api_key=API_KEY)
+    with pytest.raises(ShrtnrError) as exc_info:
+        await client.links.list()
+    assert exc_info.value.status == 0
+
+
 # ---- Links resource ----
 
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -137,6 +137,17 @@ def test_network_error_wraps_as_status_0(client: Shrtnr) -> None:
         assert exc_info.value.status == 0
 
 
+def test_malformed_base_url_wraps_as_status_0() -> None:
+    # httpx.InvalidURL (e.g. a bad port) is raised synchronously from
+    # request-building, before any I/O, and is not a subclass of
+    # httpx.RequestError. It must still surface as the documented
+    # ShrtnrError(status=0, ...), not escape as a raw httpx exception.
+    client = Shrtnr(base_url="https://example.com:notaport", api_key=API_KEY)
+    with pytest.raises(ShrtnrError) as exc_info:
+        client.links.list()
+    assert exc_info.value.status == 0
+
+
 # ---- Base URL normalization ----
 
 

--- a/src/__tests__/repository/slug-repository.test.ts
+++ b/src/__tests__/repository/slug-repository.test.ts
@@ -201,6 +201,24 @@ describe("SlugRepository.disable", () => {
     expect(primaries).toHaveLength(1);
     expect(primaries[0].slug).toBe("dsprim-c2");
   });
+
+  it("refuses to disable the system-generated slug, even called directly", async () => {
+    // disableSlug in link-management.ts already blocks this before it
+    // reaches the repository, but the repository must not rely solely on
+    // that: a link has exactly one is_custom = 0 slug for its whole
+    // lifetime, so the primary-fallback query below (which promotes by
+    // is_custom = 0) would re-select this very row and then immediately
+    // demote it, leaving the link with no primary slug at all.
+    const link = await LinkRepository.create(env.DB, { url: "https://example.com", slug: "onlyauto" });
+    const result = await SlugRepository.disable(env.DB, "onlyauto");
+    expect(result).toBeNull();
+
+    const updated = await LinkRepository.getById(env.DB, link.id);
+    expect(updated!.slugs.find((s) => s.slug === "onlyauto")!.disabled_at).toBeNull();
+    const primaries = updated!.slugs.filter((s) => s.is_primary);
+    expect(primaries).toHaveLength(1);
+    expect(primaries[0].slug).toBe("onlyauto");
+  });
 });
 
 describe("SlugRepository.enable", () => {

--- a/src/__tests__/unit/client-custom-slug-toast.test.ts
+++ b/src/__tests__/unit/client-custom-slug-toast.test.ts
@@ -1,0 +1,136 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+// createLink() makes two API calls when the "New Link" modal's custom-slug
+// field is filled in: create the link, then attach the custom slug. The
+// second call's success and failure branches used to show the identical
+// "Link created" toast either way, so a rejected custom slug (already
+// taken, invalid) failed silently: the user was told the slug they asked
+// for was attached when it wasn't. This drives createLink() against a
+// stubbed api() that succeeds on the first call and fails on the second,
+// and asserts the failure actually surfaces.
+import { describe, expect, it } from "vitest";
+import { adminClientScript } from "../../client";
+import type { Translations } from "../../i18n/types";
+
+function extractTopLevelChunk(source: string, startPattern: RegExp): string {
+  const lines = source.split("\n");
+  const startIdx = lines.findIndex((l) => startPattern.test(l));
+  if (startIdx === -1) throw new Error(`chunk not found: ${startPattern}`);
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^(function |var |if |window\.|document\.)/.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+  return lines.slice(startIdx, endIdx).join("\n");
+}
+
+type ToastCall = { message: string; level?: string };
+
+// Fields read by createLink(): url and custom are the interesting ones,
+// label/len/expires are left blank so the request body stays minimal.
+function fakeDocument() {
+  const values: Record<string, string> = {
+    "m-url": "https://example.com",
+    "m-label": "",
+    "m-len": "",
+    "m-custom": "taken-slug",
+    "m-expires": "",
+  };
+  return {
+    getElementById: (id: string) => ({ value: values[id] ?? "", focus() {} }),
+  };
+}
+
+// First api() call (create the link) resolves ok with a link id; second
+// call (attach the custom slug) resolves with whatever `slugOk`/`slugJson`
+// says, mirroring a real POST /links/:id/slugs response.
+function loadCreateLink(slugOk: boolean, slugJson: () => Promise<unknown>) {
+  const script = adminClientScript("1.0.0", {} as unknown as Translations);
+  const code = [
+    extractTopLevelChunk(script, /^function createLink\(/),
+    extractTopLevelChunk(script, /^function attachCustomSlugAndGo\(/),
+    "return { createLink: createLink };",
+  ].join("\n");
+
+  const toasts: ToastCall[] = [];
+  let call = 0;
+  const api = () => {
+    call += 1;
+    if (call === 1) {
+      return Promise.resolve({
+        ok: true,
+        status: 201,
+        json: () => Promise.resolve({ id: 42 }),
+      });
+    }
+    return Promise.resolve({ ok: slugOk, status: slugOk ? 200 : 409, json: slugJson });
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const factory = new Function(
+    "api",
+    "toast",
+    "t",
+    "closeModal",
+    "window",
+    "document",
+    code,
+  ) as (...args: unknown[]) => { createLink: () => void };
+
+  const window_ = { location: { href: "" } };
+  const handlers = factory(
+    api,
+    (message: string, level?: string) => {
+      toasts.push({ message, level });
+    },
+    (key: string) => key,
+    () => {},
+    window_,
+    fakeDocument(),
+  );
+  return { handlers, toasts, window: window_ };
+}
+
+async function waitForToast(toasts: ToastCall[]) {
+  for (let i = 0; i < 50 && toasts.length === 0; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("createLink() custom-slug attach toast", () => {
+  it("toasts a distinct error when attaching the requested custom slug fails", async () => {
+    const { handlers, toasts, window: win } = loadCreateLink(false, () =>
+      Promise.resolve({ error: "slug already taken" }),
+    );
+
+    handlers.createLink();
+    await waitForToast(toasts);
+
+    expect(toasts).toEqual([{ message: "slug already taken", level: "error" }]);
+    // The link itself was created, so the user still lands on its detail page.
+    expect(win.location.href).toBe("/_/admin/links/42");
+  });
+
+  it("falls back to a generic custom-slug error when the failure body has no message", async () => {
+    const { handlers, toasts } = loadCreateLink(false, () => Promise.reject(new Error("no body")));
+
+    handlers.createLink();
+    await waitForToast(toasts);
+
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].level).toBe("error");
+    expect(toasts[0].message).toBe("client.customError");
+  });
+
+  it("toasts the success message when the custom slug attaches", async () => {
+    const { handlers, toasts } = loadCreateLink(true, () => Promise.resolve({}));
+
+    handlers.createLink();
+    await waitForToast(toasts);
+
+    expect(toasts).toEqual([{ message: "client.linkCreated", level: undefined }]);
+  });
+});

--- a/src/__tests__/unit/client-t-replacer.test.ts
+++ b/src/__tests__/unit/client-t-replacer.test.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 Oddbit (https://oddbit.id)
+// SPDX-License-Identifier: Apache-2.0
+
+// The admin client script's t() interpolates {param} placeholders into a
+// translation string. src/i18n/index.ts's createTranslateFn() already
+// guards this with a replacer function instead of a plain string, because
+// String.prototype.replace treats "$&", "$`", "$'", "$1" etc. in a string
+// replacement as special patterns instead of literal text. t() in
+// client.ts reimplements the same interpolation client-side and needs the
+// same guard, or a param value containing one of those sequences (an API
+// key title, a bundle name — both free text) corrupts the rendered string.
+import { describe, expect, it } from "vitest";
+import { adminClientScript } from "../../client";
+import type { Translations } from "../../i18n/types";
+
+function extractTopLevelChunk(source: string, startPattern: RegExp): string {
+  const lines = source.split("\n");
+  const startIdx = lines.findIndex((l) => startPattern.test(l));
+  if (startIdx === -1) throw new Error(`chunk not found: ${startPattern}`);
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^(function |var |if |window\.|document\.)/.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+  return lines.slice(startIdx, endIdx).join("\n");
+}
+
+function loadT(translations: Record<string, string>) {
+  const script = adminClientScript("1.0.0", {} as unknown as Translations);
+  const code = [
+    `var T = ${JSON.stringify(translations)};`,
+    extractTopLevelChunk(script, /^function t\(/),
+    "return t;",
+  ].join("\n");
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const factory = new Function(code) as () => (key: string, params?: Record<string, unknown>) => string;
+  return factory();
+}
+
+describe("client.ts t()", () => {
+  it("interpolates a plain {param} value", () => {
+    const t = loadT({ greeting: "Hello {name}!" });
+    expect(t("greeting", { name: "World" })).toBe("Hello World!");
+  });
+
+  it("treats interpolated values as literal text, not replacement patterns", () => {
+    const t = loadT({ confirm: 'Delete "{title}"?' });
+    // "$`" is a special String.replace pattern (text before the match). A
+    // naive `val.replace(re, String(v))` would splice that in instead of
+    // the literal value.
+    expect(t("confirm", { title: "x$`y" })).toBe('Delete "x$`y"?');
+  });
+
+  it("does not collapse a literal $$ in the interpolated value", () => {
+    const t = loadT({ label: "{name}" });
+    expect(t("label", { name: "Q1 $$" })).toBe("Q1 $$");
+  });
+});

--- a/src/__tests__/unit/qr.test.ts
+++ b/src/__tests__/unit/qr.test.ts
@@ -72,3 +72,94 @@ describe("makeQR", () => {
     expect(makeQR(tooLong)).toBeNull();
   });
 });
+
+// Scannability: a real decoder (jsQR) must read back what makeQR() wrote.
+// The rendering assertions above cannot see a broken error-correction
+// layout or a missing version-info block; a decoder can.
+import jsQR from "jsqr";
+
+function rasterize(matrix: boolean[][], scale = 4, quiet = 4): { data: Uint8ClampedArray; width: number } {
+  const modules = matrix.length + quiet * 2;
+  const width = modules * scale;
+  const data = new Uint8ClampedArray(width * width * 4).fill(255);
+  for (let r = 0; r < matrix.length; r++) {
+    for (let c = 0; c < matrix.length; c++) {
+      if (!matrix[r][c]) continue;
+      for (let dy = 0; dy < scale; dy++) {
+        for (let dx = 0; dx < scale; dx++) {
+          const x = (c + quiet) * scale + dx;
+          const y = (r + quiet) * scale + dy;
+          const i = (y * width + x) * 4;
+          data[i] = 0;
+          data[i + 1] = 0;
+          data[i + 2] = 0;
+        }
+      }
+    }
+  }
+  return { data, width };
+}
+
+function decode(matrix: boolean[][]): string | null {
+  const { data, width } = rasterize(matrix);
+  return jsQR(data, width, width)?.data ?? null;
+}
+
+// Byte-mode capacity at error-correction level L, indexed by version.
+const CAPACITY_L = [0, 17, 32, 53, 78, 106, 134, 154, 192, 230, 271];
+
+describe("makeQR scannability", () => {
+  for (let ver = 1; ver <= 10; ver++) {
+    it(`version ${ver}: a payload filling the version decodes back to the same text`, () => {
+      const prefix = "https://s.ex/";
+      const text = prefix + "a".repeat(CAPACITY_L[ver] - prefix.length);
+      const grid = makeQR(text);
+      expect(grid).not.toBeNull();
+      expect(grid!.length).toBe(ver * 4 + 17);
+      expect(decode(grid!)).toBe(text);
+    });
+  }
+
+  it("decodes a realistic short link with utm_medium=qr", () => {
+    const text = "https://s.example/very-long-custom-slug-for-a-marketing-campaign?utm_medium=qr";
+    expect(decode(makeQR(text)!)).toBe(text);
+  });
+
+  it("encodes exactly 271 bytes (version 10 capacity) and refuses 272", () => {
+    expect(makeQR("x".repeat(271))).not.toBeNull();
+    expect(makeQR("x".repeat(272))).toBeNull();
+  });
+});
+
+describe("makeQR version information", () => {
+  // 18-bit version information (6 data bits + 12 BCH bits), ISO/IEC 18004 Table D.1.
+  const VERSION_INFO: Record<number, number> = {
+    7: 0x07c94,
+    8: 0x085bc,
+    9: 0x09a99,
+    10: 0x0a4d3,
+  };
+
+  function readVersionInfo(grid: boolean[][]): { topRight: number; bottomLeft: number } {
+    const size = grid.length;
+    let topRight = 0;
+    let bottomLeft = 0;
+    for (let i = 0; i < 18; i++) {
+      const a = size - 11 + (i % 3);
+      const b = Math.floor(i / 3);
+      if (grid[b][a]) topRight |= 1 << i;
+      if (grid[a][b]) bottomLeft |= 1 << i;
+    }
+    return { topRight, bottomLeft };
+  }
+
+  for (const ver of [7, 8, 9, 10]) {
+    it(`version ${ver}: both version-info blocks carry the BCH-encoded version`, () => {
+      const grid = makeQR("x".repeat(CAPACITY_L[ver - 1] + 1))!;
+      expect(grid.length).toBe(ver * 4 + 17);
+      const { topRight, bottomLeft } = readVersionInfo(grid);
+      expect(topRight).toBe(VERSION_INFO[ver]);
+      expect(bottomLeft).toBe(VERSION_INFO[ver]);
+    });
+  }
+});

--- a/src/__tests__/unit/title-fetch.test.ts
+++ b/src/__tests__/unit/title-fetch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { extractTitle, fetchPageTitle } from "../../title-fetch";
+import { extractTitle, fetchPageTitle, isPublicHttpUrl } from "../../title-fetch";
 
 describe("extractTitle", () => {
   it("extracts a plain title", () => {
@@ -68,5 +68,158 @@ describe("fetchPageTitle", () => {
 
     expect(result).toBeNull();
     expect(cancelCalled).toBe(true);
+  });
+});
+
+function htmlResponse(title: string): Response {
+  return new Response(`<html><head><title>${title}</title></head><body></body></html>`, {
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+function redirectResponse(location: string): Response {
+  return new Response(null, { status: 302, headers: { location } });
+}
+
+describe("fetchPageTitle SSRF guard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("fetches a public https URL and returns its title", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(htmlResponse("Public Page"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchPageTitle("https://example.com/article")).toBe("Public Page");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://example.com/article");
+  });
+
+  const blocked: [string, string][] = [
+    ["non-http scheme (ftp)", "ftp://example.com/"],
+    ["non-http scheme (file)", "file:///etc/passwd"],
+    ["non-http scheme (gopher)", "gopher://example.com/"],
+    ["unparsable URL", "not a url"],
+    ["localhost", "http://localhost/admin"],
+    ["localhost subdomain", "http://db.localhost/"],
+    [".internal hostname", "http://metadata.google.internal/computeMetadata/v1/"],
+    [".local hostname", "http://printer.local/"],
+    ["IPv4 loopback", "http://127.0.0.1:8787/"],
+    ["IPv4 loopback, other address in /8", "http://127.1.2.3/"],
+    ["IPv4 loopback as a decimal integer", "http://2130706433/"],
+    ["IPv4 loopback as hex octets", "http://0x7f.0.0.1/"],
+    ["unspecified 0.0.0.0", "http://0.0.0.0/"],
+    ["RFC 1918 10/8", "http://10.0.0.5/"],
+    ["RFC 1918 172.16/12", "http://172.31.255.254/"],
+    ["RFC 1918 192.168/16", "http://192.168.1.1/"],
+    ["link-local / cloud metadata", "http://169.254.169.254/latest/meta-data/"],
+    ["shared address space 100.64/10", "http://100.127.0.1/"],
+    ["multicast", "http://224.0.0.1/"],
+    ["broadcast", "http://255.255.255.255/"],
+    ["IPv6 loopback", "http://[::1]/"],
+    ["IPv6 unspecified", "http://[::]/"],
+    ["IPv6 unique local fc00::/7", "http://[fd12:3456::1]/"],
+    ["IPv6 link-local fe80::/10", "http://[fe80::1]/"],
+    ["IPv4-mapped IPv6 loopback", "http://[::ffff:127.0.0.1]/"],
+    ["IPv4-mapped IPv6 private", "http://[::ffff:10.0.0.1]/"],
+    ["NAT64 prefix wrapping loopback", "http://[64:ff9b::7f00:1]/"],
+  ];
+
+  for (const [label, url] of blocked) {
+    it(`refuses to fetch ${label}: ${url}`, async () => {
+      const fetchMock = vi.fn().mockResolvedValue(htmlResponse("Should Not Be Read"));
+      vi.stubGlobal("fetch", fetchMock);
+
+      expect(await fetchPageTitle(url)).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  }
+
+  it("does not let the server follow redirects on its own", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(htmlResponse("Page"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchPageTitle("https://example.com/");
+
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: "manual" });
+  });
+
+  it("follows a redirect to another public host and reads the title there", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse("https://www.example.org/landing"))
+      .mockResolvedValueOnce(htmlResponse("Landing"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchPageTitle("https://example.com/")).toBe("Landing");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe("https://www.example.org/landing");
+  });
+
+  it("resolves a relative redirect against the current URL", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse("/moved"))
+      .mockResolvedValueOnce(htmlResponse("Moved"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchPageTitle("https://example.com/old")).toBe("Moved");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://example.com/moved");
+  });
+
+  it("refuses a redirect that lands on a private address", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse("http://169.254.169.254/latest/meta-data/"))
+      .mockResolvedValue(htmlResponse("Metadata"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchPageTitle("https://example.com/")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a redirect to a non-http scheme", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse("file:///etc/hosts"))
+      .mockResolvedValue(htmlResponse("Hosts"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchPageTitle("https://example.com/")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up on a redirect loop instead of following it forever", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(redirectResponse("https://example.com/loop"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchPageTitle("https://example.com/loop")).toBeNull();
+    expect(fetchMock.mock.calls.length).toBeLessThanOrEqual(6);
+  });
+
+  it("returns null on a redirect without a Location header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 302 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await fetchPageTitle("https://example.com/")).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isPublicHttpUrl", () => {
+  it("accepts public hostnames and public IP literals", () => {
+    expect(isPublicHttpUrl("https://example.com/")).toBe(true);
+    expect(isPublicHttpUrl("http://93.184.216.34/")).toBe(true);
+    expect(isPublicHttpUrl("https://[2606:2800:220:1:248:1893:25c8:1946]/")).toBe(true);
+    expect(isPublicHttpUrl("http://172.15.255.255/")).toBe(true);
+    expect(isPublicHttpUrl("http://172.32.0.1/")).toBe(true);
+  });
+
+  it("rejects private, loopback, link-local and non-http targets", () => {
+    expect(isPublicHttpUrl("http://127.0.0.1/")).toBe(false);
+    expect(isPublicHttpUrl("http://172.16.0.1/")).toBe(false);
+    expect(isPublicHttpUrl("http://[::1]/")).toBe(false);
+    expect(isPublicHttpUrl("ftp://example.com/")).toBe(false);
+    expect(isPublicHttpUrl("nope")).toBe(false);
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -34,7 +34,10 @@ function t(key, params) {
   var val = T[key] || key;
   if (params) {
     for (var k in params) {
-      val = val.replace(new RegExp('\\\\{' + k + '\\\\}', 'g'), String(params[k]));
+      // Replacer function, not a string: a string replacement treats
+      // "$&", "$\`", "$'", "$1" etc. in the value as special patterns
+      // instead of literal text.
+      val = val.replace(new RegExp('\\\\{' + k + '\\\\}', 'g'), function() { return String(params[k]); });
     }
   }
   return val;

--- a/src/client.ts
+++ b/src/client.ts
@@ -257,21 +257,31 @@ function createLink() {
           window.location.href = '/_/admin/links/' + link.id;
           return;
         }
-        api('/links/' + link.id + '/slugs', { method: 'POST', body: JSON.stringify({ slug: custom }) }).then(function(slugRes) {
-          closeModal();
-          if (!slugRes.ok) {
-            toast(t('client.linkCreated'));
-          } else {
-            toast(t('client.linkCreated'));
-          }
-          window.location.href = '/_/admin/links/' + link.id;
-        });
+        attachCustomSlugAndGo(link.id, custom);
       });
     } else {
       return res.json().then(function(data) {
         toast(data.error || t('client.createLinkError'), 'error');
       }).catch(function() { toast(t('client.createLinkError'), 'error'); });
     }
+  });
+}
+
+// Attaches a custom slug to a just-created link, reporting whether the
+// slug itself was accepted (it may already be taken) separately from the
+// link creation that already succeeded by the time this runs.
+function attachCustomSlugAndGo(linkId, slug) {
+  api('/links/' + linkId + '/slugs', { method: 'POST', body: JSON.stringify({ slug: slug }) }).then(function(slugRes) {
+    closeModal();
+    if (!slugRes.ok) {
+      return slugRes.json().then(function(data) {
+        toast(data.error || t('client.customError'), 'error');
+      }).catch(function() { toast(t('client.customError'), 'error'); }).then(function() {
+        window.location.href = '/_/admin/links/' + linkId;
+      });
+    }
+    toast(t('client.linkCreated'));
+    window.location.href = '/_/admin/links/' + linkId;
   });
 }
 

--- a/src/db/slug-repository.ts
+++ b/src/db/slug-repository.ts
@@ -91,6 +91,17 @@ export class SlugRepository {
     const row = await SlugRepository.findByValue(db, slug);
     if (!row) return null;
 
+    // A link has exactly one system-generated (is_custom = 0) slug for its
+    // whole lifetime, so it can never stand in as "another auto slug" for
+    // itself: the primary-fallback query below promotes by `is_custom = 0`,
+    // and disabling the one and only such row would have that query
+    // re-select the very row being demoted next, leaving the link with no
+    // primary slug at all. The only current caller (disableSlug in
+    // link-management.ts) already refuses this before reaching here; this
+    // guard makes the repository enforce its own invariant rather than rely
+    // solely on that caller.
+    if (!row.is_custom) return null;
+
     // Disable and the primary fallback run in one transactional batch so a
     // failure cannot strand the link without a primary slug. The handover
     // re-checks inside the batch that this slug still holds primary: a

--- a/src/qr.ts
+++ b/src/qr.ts
@@ -55,11 +55,16 @@ export function makeQR(text: string): boolean[][] | null {
     ];
     const aligns = alignTable[ver];
     if (Array.isArray(aligns)) {
+      const last = aligns.length - 1;
       for (let ai = 0; ai < aligns.length; ai++) {
         for (let aj = 0; aj < aligns.length; aj++) {
+          // Skip the three positions that fall inside a finder pattern. Only
+          // those: from version 7 on, alignment patterns also sit on the
+          // timing pattern's row and column, which are reserved too, and
+          // those must be drawn.
+          if ((ai === 0 && aj === 0) || (ai === 0 && aj === last) || (ai === last && aj === 0)) continue;
           const ar = aligns[ai];
           const ac = aligns[aj];
-          if (reserved[ar] && reserved[ar][ac]) continue;
           for (let dr = -2; dr <= 2; dr++) {
             for (let dc = -2; dc <= 2; dc++) {
               const rr = ar + dr;
@@ -85,10 +90,32 @@ export function makeQR(text: string): boolean[][] | null {
   reserved[size - 8][8] = 1;
   grid[size - 8][8] = 1;
 
-  const eccL = [0, 7, 10, 15, 20, 26, 18, 20, 24, 30, 18];
+  // Version information (versions 7+): two 6x3 blocks, one above the
+  // bottom-left finder and one left of the top-right finder. Reserve them
+  // before data placement so codewords route around them, then write the
+  // 18-bit BCH-protected version number into both.
+  if (ver >= 7) {
+    const versionBits = versionInfoBits(ver);
+    for (let i = 0; i < 18; i++) {
+      const bit = (versionBits >>> i) & 1;
+      const a = size - 11 + (i % 3);
+      const b = Math.floor(i / 3);
+      reserved[b][a] = 1;
+      grid[b][a] = bit;
+      reserved[a][b] = 1;
+      grid[a][b] = bit;
+    }
+  }
+
+  // Error-correction level L block structure (ISO/IEC 18004 Table 9).
+  // Versions 6-10 split the codewords into several Reed-Solomon blocks,
+  // each with its own ECC codewords, interleaved byte by byte.
+  const eccPerBlockL = [0, 7, 10, 15, 20, 26, 18, 20, 24, 30, 18];
+  const numBlocksL = [0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4];
   const totalCodewords = [0, 26, 44, 70, 100, 134, 172, 196, 242, 292, 346];
-  const numEcc = eccL[ver];
-  const numData = totalCodewords[ver] - numEcc;
+  const numEcc = eccPerBlockL[ver];
+  const numBlocks = numBlocksL[ver];
+  const numData = totalCodewords[ver] - numEcc * numBlocks;
 
   let bits = "";
   bits += "0100";
@@ -108,8 +135,7 @@ export function makeQR(text: string): boolean[][] | null {
 
   const dataBytes: number[] = [];
   for (let i = 0; i < bits.length; i += 8) dataBytes.push(parseInt(bits.slice(i, i + 8), 2));
-  const eccBytes = rsEncode(dataBytes, numEcc);
-  const allBytes = dataBytes.concat(eccBytes);
+  const allBytes = interleaveBlocks(dataBytes, totalCodewords[ver], numBlocks, numEcc);
 
   let bitStr = "";
   for (let i = 0; i < allBytes.length; i++) bitStr += toBin(allBytes[i], 8);
@@ -159,6 +185,51 @@ export function makeQR(text: string): boolean[][] | null {
 
 function toBin(n: number, len: number): string {
   return n.toString(2).padStart(len, "0");
+}
+
+/**
+ * 18-bit version information: the 6-bit version number followed by its
+ * 12-bit BCH(18,6) remainder over the generator polynomial 0x1F25.
+ */
+function versionInfoBits(ver: number): number {
+  let rem = ver;
+  for (let i = 0; i < 12; i++) {
+    rem = (rem << 1) ^ ((rem >>> 11) * 0x1f25);
+  }
+  return (ver << 12) | rem;
+}
+
+/**
+ * Split the data codewords into Reed-Solomon blocks, compute ECC for each,
+ * and interleave them as the spec requires: all blocks' first data byte,
+ * then all blocks' second data byte, ... then the ECC bytes the same way.
+ * When the codeword count does not divide evenly, the leading blocks are
+ * one data byte shorter than the trailing ones.
+ */
+function interleaveBlocks(data: number[], totalCodewords: number, numBlocks: number, eccPerBlock: number): number[] {
+  const numShortBlocks = numBlocks - (totalCodewords % numBlocks);
+  const shortBlockLen = Math.floor(totalCodewords / numBlocks);
+  const shortDataLen = shortBlockLen - eccPerBlock;
+
+  const blocks: { data: number[]; ecc: number[] }[] = [];
+  let offset = 0;
+  for (let b = 0; b < numBlocks; b++) {
+    const dataLen = shortDataLen + (b < numShortBlocks ? 0 : 1);
+    const blockData = data.slice(offset, offset + dataLen);
+    offset += dataLen;
+    blocks.push({ data: blockData, ecc: rsEncode(blockData, eccPerBlock) });
+  }
+
+  const out: number[] = [];
+  for (let i = 0; i <= shortDataLen; i++) {
+    for (const block of blocks) {
+      if (i < block.data.length) out.push(block.data[i]);
+    }
+  }
+  for (let i = 0; i < eccPerBlock; i++) {
+    for (const block of blocks) out.push(block.ecc[i]);
+  }
+  return out;
 }
 
 function rsEncode(data: number[], numEcc: number): number[] {

--- a/src/title-fetch.ts
+++ b/src/title-fetch.ts
@@ -1,17 +1,154 @@
 // Copyright 2026 Oddbit (https://oddbit.id)
 // SPDX-License-Identifier: Apache-2.0
 
+/** Redirect hops fetchPageTitle() follows before giving up. */
+const MAX_REDIRECTS = 5;
+
+/**
+ * Decides whether the server may fetch this URL on the user's behalf.
+ *
+ * Link URLs are user-supplied, so this fetch is a server-side request
+ * forgery surface: without a guard, a link pointing at a loopback, RFC 1918,
+ * link-local or cloud-metadata address would have the Worker fetch it and
+ * store the response's <title> where the link's owner can read it.
+ * Cloudflare Workers already refuse most such destinations, but the guard
+ * does not rely on that: only http(s) URLs whose host is a public name or
+ * a public IP literal pass.
+ *
+ * Hostnames are not resolved here (Workers expose no DNS lookup), so a
+ * public name that resolves to a private address is not caught. That gap
+ * is closed by the platform's own egress restrictions.
+ */
+export function isPublicHttpUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+
+  const host = parsed.hostname.toLowerCase();
+  if (!host) return false;
+
+  if (host.startsWith("[") && host.endsWith("]")) {
+    const groups = parseIPv6(host.slice(1, -1));
+    return groups !== null && !isReservedIPv6(groups);
+  }
+
+  // URL parsing already normalized decimal, octal and hex IPv4 spellings
+  // (2130706433, 0x7f.0.0.1, 0177.0.0.1) into dotted quads, so one check
+  // on the normalized form covers every spelling.
+  const octets = parseIPv4(host);
+  if (octets) return !isReservedIPv4(octets);
+
+  if (host === "localhost" || host.endsWith(".localhost")) return false;
+  if (host.endsWith(".internal") || host.endsWith(".local")) return false;
+  return true;
+}
+
+function parseIPv4(host: string): number[] | null {
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return null;
+  const octets = m.slice(1).map(Number);
+  return octets.every((o) => o <= 255) ? octets : null;
+}
+
+function isReservedIPv4([a, b]: number[]): boolean {
+  if (a === 0) return true; // 0.0.0.0/8 "this" network
+  if (a === 10) return true; // RFC 1918
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 shared address space
+  if (a === 127) return true; // loopback
+  if (a === 169 && b === 254) return true; // link-local, cloud metadata endpoints
+  if (a === 172 && b >= 16 && b <= 31) return true; // RFC 1918
+  if (a === 192 && b === 0) return true; // 192.0.0.0/24 IETF protocol assignments, 192.0.2.0/24 TEST-NET-1
+  if (a === 192 && b === 168) return true; // RFC 1918
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast, reserved, broadcast
+  return false;
+}
+
+/** Expands an IPv6 literal (without brackets) into eight 16-bit groups. */
+function parseIPv6(host: string): number[] | null {
+  // Embedded dotted-quad tail (::ffff:127.0.0.1): fold it into two groups.
+  const lastColon = host.lastIndexOf(":");
+  const tail = host.slice(lastColon + 1);
+  if (tail.includes(".")) {
+    const octets = parseIPv4(tail);
+    if (!octets) return null;
+    const hi = ((octets[0] << 8) | octets[1]).toString(16);
+    const lo = ((octets[2] << 8) | octets[3]).toString(16);
+    host = `${host.slice(0, lastColon + 1)}${hi}:${lo}`;
+  }
+
+  const halves = host.split("::");
+  if (halves.length > 2) return null;
+  const toGroups = (part: string): number[] | null => {
+    if (part === "") return [];
+    const out: number[] = [];
+    for (const g of part.split(":")) {
+      if (!/^[0-9a-f]{1,4}$/i.test(g)) return null;
+      out.push(parseInt(g, 16));
+    }
+    return out;
+  };
+  const head = toGroups(halves[0]);
+  const rest = halves.length === 2 ? toGroups(halves[1]) : [];
+  if (!head || !rest) return null;
+  if (halves.length === 1) return head.length === 8 ? head : null;
+  const missing = 8 - head.length - rest.length;
+  if (missing < 1) return null;
+  return [...head, ...new Array(missing).fill(0), ...rest];
+}
+
+function isReservedIPv6(g: number[]): boolean {
+  const leadingZero = g.slice(0, 5).every((x) => x === 0);
+  // :: (unspecified) and ::1 (loopback)
+  if (leadingZero && g[5] === 0 && g[6] === 0 && (g[7] === 0 || g[7] === 1)) return true;
+  // ::ffff:a.b.c.d IPv4-mapped: judge the embedded IPv4 address
+  if (leadingZero && g[5] === 0xffff) return isReservedIPv4(groupsToIPv4(g[6], g[7]));
+  // 64:ff9b::/96 NAT64: same, the last 32 bits are an IPv4 address
+  if (g[0] === 0x64 && g[1] === 0xff9b && g.slice(2, 6).every((x) => x === 0)) {
+    return isReservedIPv4(groupsToIPv4(g[6], g[7]));
+  }
+  if ((g[0] & 0xfe00) === 0xfc00) return true; // fc00::/7 unique local
+  if ((g[0] & 0xffc0) === 0xfe80) return true; // fe80::/10 link-local
+  if ((g[0] & 0xffc0) === 0xfec0) return true; // fec0::/10 site-local (deprecated)
+  if ((g[0] & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  return false;
+}
+
+function groupsToIPv4(hi: number, lo: number): number[] {
+  return [hi >>> 8, hi & 0xff, lo >>> 8, lo & 0xff];
+}
+
 /**
  * Fetches the page at the given URL and extracts the <title> content.
- * Returns null if the page cannot be fetched or has no title.
+ * Returns null if the page cannot be fetched, points at a non-public
+ * address, or has no title. Redirects are followed by hand so every hop
+ * passes the same public-address check as the starting URL.
  */
 export async function fetchPageTitle(url: string): Promise<string | null> {
   try {
-    const res = await fetch(url, {
-      headers: { "User-Agent": "Shrtnr/1.0 (link preview)" },
-      redirect: "follow",
-      signal: AbortSignal.timeout(5000),
-    });
+    let current = url;
+    let res: Response | null = null;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+      if (!isPublicHttpUrl(current)) return null;
+      const candidate = await fetch(current, {
+        headers: { "User-Agent": "Shrtnr/1.0 (link preview)" },
+        redirect: "manual",
+        signal: AbortSignal.timeout(5000),
+      });
+      if (candidate.status < 300 || candidate.status > 399) {
+        res = candidate;
+        break;
+      }
+      await candidate.body?.cancel();
+      const location = candidate.headers.get("location");
+      if (!location) return null;
+      current = new URL(location, current).toString();
+    }
+    if (!res) return null;
 
     const contentType = res.headers.get("content-type") ?? "";
     if (!contentType.includes("text/html") && !contentType.includes("application/xhtml")) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,6 +1444,11 @@ json-schema-typed@^8.0.2:
   resolved "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz"
   integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
+jsqr@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsqr/-/jsqr-1.4.0.tgz#8efb8d0a7cc6863cb6d95116b9069123ce9eb2d1"
+  integrity sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==
+
 kleur@^4.1.5:
   version "4.1.5"
   resolved "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz"


### PR DESCRIPTION
Weekly defect-hunting review of the app, its API, and all three SDKs. Six parallel passes (API/DB/services, admin UI, MCP/auth, TypeScript SDK, Python SDK, Dart SDK), each finding verified against the actual code and a failing-before/passing-after regression test before being fixed.

## Fixes

**`createLink()`'s custom-slug attach toasted "Link created" whether it succeeded or failed** (`src/client.ts`)
- Wrong: the "New Link" modal's custom-slug branch had `if (!slugRes.ok) { toast(t('client.linkCreated')); } else { toast(t('client.linkCreated')); }` — both branches identical.
- Impact: requesting a custom slug that's already taken (or otherwise rejected) failed silently. The user was told "Link created" and redirected to the link's detail page with no sign the slug they asked for never attached.
- Fix: extracted the step into `attachCustomSlugAndGo()`, which reads the failure body and toasts `client.customError` (or the server's message), matching `doAddSlug`'s existing handling of the same endpoint.
- Test: drives `createLink()` against a stubbed `api()` that succeeds on the link-create call and fails on the slug-attach call; asserts the failure surfaces, the generic fallback fires when the body carries no message, and the success toast still fires when the slug attaches.

**Client-side `t()` used unsafe string-based interpolation** (`src/client.ts`)
- Wrong: `val.replace(new RegExp(...), String(params[k]))` — the plain-string form of `.replace()` treats `$&`, `` $` ``, `$'`, `$1` etc. in the *replacement string* as special patterns instead of literal text. The server-side `createTranslateFn()` in `src/i18n/index.ts` already guards against exactly this with a replacer function; the client-side reimplementation didn't.
- Impact: any `$`-containing free text passed as a param corrupts the shown string. Two real call sites: API key titles (`client.confirmDeleteKey`) and bundle names (`client.bundles.confirmArchive`/`confirmDelete`), both unrestricted free text. A title like `Prod $$ key` renders as `Prod $ key`.
- Fix: pass a replacer function, mirroring the server-side fix.
- Test: extracts `t()` from the generated script and asserts literal interpolation, mirroring the existing server-side regression test for the same bug class.

**Python SDK: `httpx.InvalidURL` escaped as a raw exception instead of `ShrtnrError`** (`sdk/python/src/shrtnr/resources/{links,bundles,slugs}.py`)
- Wrong: every resource's `_request`/`_request_text` (8 call sites, sync and async) caught only `httpx.RequestError`. `httpx.InvalidURL` (e.g. an unparsable port) is not a subclass of it, and is raised synchronously from request-building, before any I/O.
- Impact: a malformed `base_url` (bad port, bad IDNA host, etc.) raised a raw `httpx.InvalidURL` instead of the documented `ShrtnrError(status=0, ...)`, breaking the "network failures wrap as `ShrtnrError`" contract in `errors.py` and the README.
- Fix: widened the caught exception tuple to `(httpx.RequestError, httpx.InvalidURL)` at all 8 sites.
- Test: one regression test per sync/async client, constructing a client with a malformed `base_url` and asserting `ShrtnrError(status=0)`.
- Single-SDK change: this is an httpx-specific exception-hierarchy quirk (`InvalidURL` isn't related to `RequestError`). The TypeScript SDK's fetch-based error handling and the Dart SDK's `http` client don't have an equivalent split, so there's nothing to port.

**`SlugRepository.disable()` could zero out a link's primary flag** (`src/db/slug-repository.ts`)
- Wrong: a link has exactly one system-generated (`is_custom = 0`) slug for its whole lifetime. `disable()`'s primary-fallback query promotes by `is_custom = 0`, so disabling that one row has the query re-select the very row being demoted next, leaving the link with no primary slug at all.
- Impact: currently unreachable — the only caller (`disableSlug` in `link-management.ts`) already refuses to disable a non-custom slug before reaching the repository — but a landmine for any future caller (MCP tool, script, admin action) that calls the repository directly.
- Fix: added the same guard `SlugRepository.remove()` already has, so the repository enforces its own invariant rather than relying solely on the one caller.
- Test: calls `SlugRepository.disable()` directly on a link's only slug (bypassing the service-layer guard) and asserts it refuses, leaving the primary flag untouched.

**QR encoder produced unscannable codes for versions 6-10** (`src/qr.ts`)
- Wrong: three stacked defects, each confirmed with a real decoder (jsQR). (1) Versions 6-10 must split codewords into 2 (v6-9) or 4 (v10) Reed-Solomon blocks and interleave them; the encoder read the per-block ECC count as the total and ran one RS pass over the whole payload. (2) Versions 7-10 must carry two 18-bit BCH-protected version-information blocks; the encoder never reserved or wrote them, so data modules landed where a reader looks for the version. (3) From version 7 on, alignment patterns also sit on the timing pattern's row and column; the "skip if reserved" test meant for the three finder overlaps also skipped those.
- Impact: any QR payload over 106 bytes (a short link with a long custom slug plus `?utm_medium=qr` gets there) rendered a symbol no reader could decode. Versions 1-5 were unaffected.
- Fix: per-version block-count table with proper block splitting and interleaving, version-information blocks reserved and written for v7+, and an index-based finder-overlap skip for alignment patterns.
- Test: rasterizes each version's output and decodes it with jsQR (new dev dependency), asserts the version-info bits against ISO/IEC 18004 Table D.1, and checks the 271-byte capacity boundary. Before the fix versions 6-10 failed to decode; after it every payload length from 1 to 271 bytes round-trips.

**`fetchPageTitle` fetched any user-supplied URL server-side with no restriction** (`src/title-fetch.ts`)
- Wrong: `autoLabelLink()` fetched the link URL with `redirect: "follow"` and no host check, an SSRF pattern. A link at a loopback, RFC 1918, link-local or cloud-metadata address (or a public page redirecting to one) had the Worker fetch it and store the response's `<title>` where the link's owner can read it.
- Impact: bounded in practice by Cloudflare Workers' own egress isolation, but the code assumed that instead of enforcing it.
- Fix: new `isPublicHttpUrl()` admits only http(s) URLs whose host is a public name or public IP literal, rejecting localhost/`.localhost`/`.internal`/`.local` names and every reserved IPv4 and IPv6 range (IPv4-mapped and NAT64 literals judged by the embedded IPv4 address; alternate IPv4 spellings are normalized by the URL parser first). `fetchPageTitle()` fetches with `redirect: "manual"` and follows up to five hops itself, vetting each `Location` before requesting it. Hostnames are not resolved (Workers expose no DNS), so a public name pointing at a private address is left to the platform.
- Test: 27 blocked targets across schemes, names and IPv4/IPv6 ranges assert `fetch` is never called; redirect tests cover public-to-public, relative `Location`, redirect-to-private, redirect-to-`file:`, redirect loops and a missing `Location`.

## Verification
- `yarn test`: 1360 tests, all green.
- `yarn e2e`: 15 failures reproduce identically (same test names, same count) on a clean `main` checkout in this sandbox — `net::ERR_CONNECTION_RESET`/browser-launch issues from the sandbox's network policy, unrelated to this diff. Verified via a side-by-side worktree run against `origin/main`.
- Python SDK: 104 tests, all green. `ruff check`/`ruff format --check`/`mypy` clean on changed files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017a43SYLJdvdDhMcgJF4zXM